### PR TITLE
Bug fixes and cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=appform-io_databuilderframework

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: java
-jdk:
-  - openjdk8
-

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+lombok.addLombokGeneratedAnnotation = true
+lombok.accessors.chain = true

--- a/pom.xml
+++ b/pom.xml
@@ -77,11 +77,13 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jackson.version>2.10.3</jackson.version>
-        <lombok.version>1.16.6</lombok.version>
+        <jackson.version>2.13.1</jackson.version>
+        <lombok.version>1.18.22</lombok.version>
         <lombok.maven.version>1.16.6.1</lombok.maven.version>
         <hibernate.validator.version>5.2.5.Final</hibernate.validator.version>
-        <junit.version>4.13.1</junit.version>
+        <junit.version>4.13.2</junit.version>
+        <logback.version>1.2.10</logback.version>
+        <slf4j.version>1.7.32</slf4j.version>
     </properties>
 
     <dependencies>
@@ -111,15 +113,14 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
-            <version>1.7.4</version>
-            <scope>provided</scope>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/ch.qos.logback/logback-classic -->
+
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>${logback.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -155,37 +156,26 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.6</version>
-                <configuration>
-                    <check>
-                        <branchRate>85</branchRate>
-                        <lineRate>85</lineRate>
-                        <haltOnFailure>true</haltOnFailure>
-                        <totalBranchRate>85</totalBranchRate>
-                        <totalLineRate>85</totalLineRate>
-                        <packageLineRate>85</packageLineRate>
-                        <packageBranchRate>85</packageBranchRate>
-                        <regexes>
-                            <regex>
-                                <pattern>io.appform.databuilderframework.*</pattern>
-                                <branchRate>100</branchRate>
-                                <lineRate>100</lineRate>
-                            </regex>
-                        </regexes>
-                    </check>
-					<instrumentation>
-						<ignoreTrivial>true</ignoreTrivial>
-					</instrumentation>
-				</configuration>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.6</version>
                 <executions>
                     <execution>
                         <goals>
-                            <goal>clean</goal>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <!-- attached to Maven test phase -->
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -224,6 +214,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -236,9 +227,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <excludePackageNames>io.appform.hope.lang.parser</excludePackageNames>
-                </configuration>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,8 @@
         <junit.version>4.13.2</junit.version>
         <logback.version>1.2.10</logback.version>
         <slf4j.version>1.7.32</slf4j.version>
+        <sonar.organization>appform-io</sonar.organization>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
 
     <dependencies>

--- a/src/main/java/io/appform/databuilderframework/annotations/DataRequestInfo.java
+++ b/src/main/java/io/appform/databuilderframework/annotations/DataRequestInfo.java
@@ -12,5 +12,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface DataRequestInfo {
-    public String value();
+    String value();
 }

--- a/src/main/java/io/appform/databuilderframework/engine/BuilderRunner.java
+++ b/src/main/java/io/appform/databuilderframework/engine/BuilderRunner.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2022 $user
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appform.databuilderframework.engine;
+
+import com.google.common.base.Preconditions;
+import io.appform.databuilderframework.model.*;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+/**
+ *
+ */
+@Slf4j
+@SuppressWarnings("java:S1181")
+final class BuilderRunner implements Callable<DataContainer> {
+    private static final String BUILDER_EXEC_ERR_MSG = "Error running builder: ";
+
+    private final List<DataBuilderExecutionListener> dataBuilderExecutionListener;
+    private final DataFlowInstance dataFlowInstance;
+    private final DataDelta dataDelta;
+    private final Map<String, Data> responseData;
+    private final DataBuilder builder;
+    private final DataBuilderMeta builderMeta;
+    private final DataBuilderContext dataBuilderContext;
+    private final Set<DataBuilderMeta> procesedBuilders;
+    private final DataSet dataSet;
+
+    @SuppressWarnings("java:S107")
+    BuilderRunner(
+            List<DataBuilderExecutionListener> dataBuilderExecutionListener,
+            DataFlowInstance dataFlowInstance,
+            DataDelta dataDelta,
+            Map<String, Data> responseData,
+            DataBuilder builder,
+            DataBuilderMeta builderMeta, DataBuilderContext dataBuilderContext,
+            Set<DataBuilderMeta> procesedBuilders,
+            DataSet dataSet) {
+        this.dataBuilderExecutionListener = dataBuilderExecutionListener;
+        this.dataFlowInstance = dataFlowInstance;
+        this.dataDelta = dataDelta;
+        this.responseData = responseData;
+        this.builder = builder;
+        this.builderMeta = builderMeta;
+        this.dataBuilderContext = dataBuilderContext;
+        this.procesedBuilders = procesedBuilders;
+        this.dataSet = dataSet;
+    }
+
+    @Override
+    public DataContainer call() throws Exception {
+
+        executePreListeners();
+        try {
+            Data response = builder.process(dataBuilderContext.immutableCopy(
+                    dataSet.accessor().getAccesibleDataSetFor(builder)));
+            procesedBuilders.add(builderMeta);
+            executePostListenersSuccess(response);
+            if (null != response) {
+                Preconditions.checkArgument(response.getData().equalsIgnoreCase(builderMeta.getProduces()),
+                                            String.format("Builder is supposed to produce %s but produces %s",
+                                                          builderMeta.getProduces(), response.getData()));
+                response.setGeneratedBy(builderMeta.getName());
+            }
+            return new DataContainer(builderMeta, response);
+        }
+        catch (DataBuilderException e) {
+            executePostExceptionListeners(e);
+            return new DataContainer(builderMeta,
+                                     new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.BUILDER_EXECUTION_ERROR,
+                                                                       BUILDER_EXEC_ERR_MSG + builderMeta.getName(),
+                                                                       e.getDetails(),
+                                                                       e));
+
+        }
+        catch (DataValidationException e) {
+            executePostExceptionListeners(e);
+            return new DataContainer(builderMeta,
+                                     new DataValidationException(DataValidationException.ErrorCode.DATA_VALIDATION_EXCEPTION,
+                                                                 BUILDER_EXEC_ERR_MSG + builderMeta.getName(),
+                                                                 new DataExecutionResponse(responseData),
+                                                                 e.getDetails(),
+                                                                 e));
+
+
+        }
+        catch (Throwable t) {
+            executePostExceptionListeners(t);
+            return new DataContainer(builderMeta,
+                                     new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.BUILDER_EXECUTION_ERROR,
+                                                                       BUILDER_EXEC_ERR_MSG + builderMeta.getName() + t.getMessage(),
+                                                                       Collections.singletonMap("MESSAGE",
+                                                                                                t.getMessage()),
+                                                                       t));
+        }
+    }
+
+    private void executePostListenersSuccess(Data response) {
+        for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
+            try {
+                listener.afterExecute(dataBuilderContext,
+                                      dataFlowInstance,
+                                      builderMeta,
+                                      dataDelta,
+                                      responseData,
+                                      response);
+            }
+            catch (Throwable t) {
+                log.error("Error running post-execution listener: ", t);
+            }
+        }
+    }
+
+    private void executePostExceptionListeners(Throwable e) {
+        log.error("Error running builder: {}", builderMeta.getName());
+        for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
+            try {
+                listener.afterException(dataBuilderContext,
+                                        dataFlowInstance,
+                                        builderMeta,
+                                        dataDelta,
+                                        responseData,
+                                        e);
+
+            }
+            catch (Throwable error) {
+                log.error("Error running post-execution listener: ", error);
+            }
+        }
+    }
+
+    private void executePreListeners() {
+        for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
+            try {
+                listener.beforeExecute(dataBuilderContext, dataFlowInstance, builderMeta, dataDelta, responseData);
+            }
+            catch (Throwable t) {
+                log.error("Error running pre-execution execution listener: ", t);
+            }
+        }
+    }
+}

--- a/src/main/java/io/appform/databuilderframework/engine/DataBuilder.java
+++ b/src/main/java/io/appform/databuilderframework/engine/DataBuilder.java
@@ -11,6 +11,7 @@ import io.appform.databuilderframework.model.DataBuilderMeta;
  * {@link io.appform.databuilderframework.annotations.DataBuilderInfo}
  * will be made available and databuilders in the system.
  */
+@lombok.Data
 @JsonTypeInfo(use= JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "name")
 public abstract class DataBuilder {
 
@@ -42,13 +43,5 @@ public abstract class DataBuilder {
      * @throws io.appform.databuilderframework.engine.DataBuilderException in case any downstream system or itself errors out.
      * (This is generic, as the upper layers need to be prepared for it).
      */
-    abstract public Data process(final DataBuilderContext context) throws DataBuilderException,DataValidationException;
-
-    public DataBuilderMeta getDataBuilderMeta() {
-        return dataBuilderMeta;
-    }
-
-    public void setDataBuilderMeta(DataBuilderMeta dataBuilderMeta) {
-        this.dataBuilderMeta = dataBuilderMeta;
-    }
+    public abstract Data process(final DataBuilderContext context) throws DataBuilderException,DataValidationException;
 }

--- a/src/main/java/io/appform/databuilderframework/engine/DataBuilderException.java
+++ b/src/main/java/io/appform/databuilderframework/engine/DataBuilderException.java
@@ -1,52 +1,47 @@
 package io.appform.databuilderframework.engine;
 
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.Value;
+
+import java.util.Collections;
 import java.util.Map;
 
 /**
  * Created by ajaysingh on 13/06/14.
  */
-public class DataBuilderException extends Exception{
-    private Map<String,Object> details;
+@Value
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class DataBuilderException extends Exception {
     public enum ErrorCode {
         HANDLER_FAILURE
     }
 
-    private final ErrorCode errorCode;
+    ErrorCode errorCode;
+    Map<String, Object> details;
 
 
     public DataBuilderException(String message) {
-        super(message);
-        this.errorCode = ErrorCode.HANDLER_FAILURE;
+        this(ErrorCode.HANDLER_FAILURE, message);
     }
 
     public DataBuilderException(ErrorCode errorCode, String message) {
-        super(message);
-        this.errorCode = errorCode;
+        this(errorCode, message, Collections.emptyMap());
     }
 
     public DataBuilderException(ErrorCode errorCode, String message, Throwable cause) {
-        super(message, cause);
-        this.errorCode = errorCode;
+        this(errorCode, message, Collections.emptyMap(), cause);
     }
 
     public DataBuilderException(ErrorCode errorCode, String message, Map<String, Object> details) {
-        super(message);
-        this.details=details;
-        this.errorCode = errorCode;
+        this(errorCode, message, details, null);
     }
 
     public DataBuilderException(ErrorCode errorCode, String message, Map<String, Object> details, Throwable cause) {
         super(message, cause);
-        this.details=details;
+        this.details = details;
         this.errorCode = errorCode;
-    }
-
-    public Map<String, Object> getDetails() {
-        return details;
-    }
-
-    public ErrorCode getErrorCode() {
-        return errorCode;
     }
 }

--- a/src/main/java/io/appform/databuilderframework/engine/DataBuilderFactory.java
+++ b/src/main/java/io/appform/databuilderframework/engine/DataBuilderFactory.java
@@ -11,7 +11,7 @@ public interface DataBuilderFactory {
      * Create a {@link DataBuilder} of the given name.
      * @param dataBuilderMeta Meta for the builder to create
      * @return A {@link DataBuilder}
-     * @throws DataBuilderFrameworkException
+     * @throws DataBuilderFrameworkException Throws error if creation failed
      */
     DataBuilder create(DataBuilderMeta dataBuilderMeta) throws DataBuilderFrameworkException;
 

--- a/src/main/java/io/appform/databuilderframework/engine/DataBuilderFrameworkException.java
+++ b/src/main/java/io/appform/databuilderframework/engine/DataBuilderFrameworkException.java
@@ -2,17 +2,19 @@ package io.appform.databuilderframework.engine;
 
 
 import io.appform.databuilderframework.model.DataExecutionResponse;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.Value;
 
+import java.util.Collections;
 import java.util.Map;
 
-public class DataBuilderFrameworkException extends Exception {
-    private Map<String,Object> details;
-	private DataExecutionResponse partialExecutionResponse;
-    public ErrorCode getErrorCode() {
-        return errorCode;
-    }
+@Value
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class DataBuilderFrameworkException extends RuntimeException {
 
-    public static enum ErrorCode {
+    public enum ErrorCode {
         PRE_PROCESSING_ERROR,
         POST_PROCESSING_ERROR,
         NO_FACTORY_FOR_DATA_BUILDER,
@@ -25,42 +27,39 @@ public class DataBuilderFrameworkException extends Exception {
         BUILDER_EXECUTION_ERROR
     }
 
-    private final ErrorCode errorCode;
+    ErrorCode errorCode;
+    Map<String, Object> details;
+    DataExecutionResponse partialExecutionResponse;
 
     public DataBuilderFrameworkException(ErrorCode errorCode, String message) {
-        super(message);
-        this.errorCode = errorCode;
+        this(errorCode, message, Collections.emptyMap());
     }
 
     public DataBuilderFrameworkException(ErrorCode errorCode, String message, Throwable cause) {
-        super(message, cause);
-        this.errorCode = errorCode;
+        this(errorCode, message, Collections.emptyMap(), cause);
     }
 
     public DataBuilderFrameworkException(ErrorCode errorCode, String message, Map<String, Object> details) {
-        super(message);
-        this.errorCode = errorCode;
-        this.details=details;
+        this(errorCode, message, details, null);
     }
 
-    public DataBuilderFrameworkException(ErrorCode errorCode, String message, Map<String, Object> details, Throwable cause) {
+    public DataBuilderFrameworkException(
+            ErrorCode errorCode,
+            String message,
+            Map<String, Object> details,
+            Throwable cause) {
+        this(errorCode, message, details, cause, null);
+    }
+
+    public DataBuilderFrameworkException(
+            ErrorCode errorCode,
+            String message,
+            Map<String, Object> details,
+            Throwable cause,
+            DataExecutionResponse partialExecutionResponse) {
         super(message, cause);
         this.errorCode = errorCode;
-        this.details=details;
+        this.details = details;
+        this.partialExecutionResponse = partialExecutionResponse;
     }
-
-	public DataBuilderFrameworkException(ErrorCode errorCode, String message, Map<String, Object> details, Throwable cause, DataExecutionResponse partialExecutionResponse){
-		super(message, cause);
-		this.errorCode = errorCode;
-		this.details = details;
-		this.partialExecutionResponse = partialExecutionResponse;
-	}
-
-    public Map<String, Object> getDetails() {
-        return details;
-    }
-
-	public DataExecutionResponse getPartialExecutionResponse() {
-		return partialExecutionResponse;
-	}
 }

--- a/src/main/java/io/appform/databuilderframework/engine/DataBuilderMetadataManager.java
+++ b/src/main/java/io/appform/databuilderframework/engine/DataBuilderMetadataManager.java
@@ -1,12 +1,10 @@
 package io.appform.databuilderframework.engine;
 
-import io.appform.databuilderframework.model.DataBuilderMeta;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
+import io.appform.databuilderframework.model.DataBuilderMeta;
+import lombok.val;
 
 import java.util.*;
 
@@ -17,20 +15,20 @@ import java.util.*;
  * data-flows respectively.
  */
 public class DataBuilderMetadataManager {
-    private Map<String, Class<? extends DataBuilder>> dataBuilders = Maps.newHashMap();
-    private Map<String, DataBuilderMeta> meta = Maps.newHashMap();
-    private Map<String, List<DataBuilderMeta>> producedToProducerMap = Maps.newHashMap();
-    private Map<String, TreeSet<DataBuilderMeta>> consumesMeta = Maps.newHashMap();
-    private Map<String, TreeSet<DataBuilderMeta>> optionalsMeta = Maps.newHashMap();
-    private Map<String, TreeSet<DataBuilderMeta>> accessesMeta = Maps.newHashMap();
-    
-    
-    private DataBuilderMetadataManager(Map<String, Class<? extends DataBuilder>> dataBuilders,
-                                       Map<String, DataBuilderMeta> meta,
-                                       Map<String, List<DataBuilderMeta>> producedToProducerMap,
-                                       Map<String, TreeSet<DataBuilderMeta>> consumesMeta,
-                                       Map<String, TreeSet<DataBuilderMeta>> optionalsMeta,
-                                       Map<String, TreeSet<DataBuilderMeta>> accessesMeta) {
+    private final Map<String, Class<? extends DataBuilder>> dataBuilders;
+    private final Map<String, DataBuilderMeta> meta;
+    private final Map<String, List<DataBuilderMeta>> producedToProducerMap;
+    private final Map<String, TreeSet<DataBuilderMeta>> consumesMeta;
+    private final Map<String, TreeSet<DataBuilderMeta>> optionalsMeta;
+    private final Map<String, TreeSet<DataBuilderMeta>> accessesMeta;
+
+    private DataBuilderMetadataManager(
+            Map<String, Class<? extends DataBuilder>> dataBuilders,
+            Map<String, DataBuilderMeta> meta,
+            Map<String, List<DataBuilderMeta>> producedToProducerMap,
+            Map<String, TreeSet<DataBuilderMeta>> consumesMeta,
+            Map<String, TreeSet<DataBuilderMeta>> optionalsMeta,
+            Map<String, TreeSet<DataBuilderMeta>> accessesMeta) {
         this.dataBuilders = dataBuilders;
         this.meta = meta;
         this.producedToProducerMap = producedToProducerMap;
@@ -40,98 +38,95 @@ public class DataBuilderMetadataManager {
     }
 
     public DataBuilderMetadataManager() {
+        this(new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>());
     }
 
     public DataBuilderMetadataManager register(Class<? extends DataBuilder> annotatedDataBuilder) throws DataBuilderFrameworkException {
-            DataBuilderMeta dataBuilderMeta = Utils.meta(annotatedDataBuilder);
-            Preconditions.checkNotNull(dataBuilderMeta,
-                    "No useful annotations found on class. Use DataBuilderInfo or DataBuilderClassInfo to annotate");
-            register(
-                    dataBuilderMeta,
-                    annotatedDataBuilder);
-        return this;
+        val dataBuilderMeta = Utils.meta(annotatedDataBuilder);
+        Objects.requireNonNull(dataBuilderMeta,
+                                   "No useful annotations found on class. Use DataBuilderInfo or DataBuilderClassInfo to annotate");
+        return register(dataBuilderMeta, annotatedDataBuilder);
     }
 
     /**
      * Register builder by using meta directly.
      *
      * @param dataBuilderMeta Meta about the builder
-     * @param dataBuilder The actual databuilder class
+     * @param dataBuilder     The actual databuilder class
      * @return this
      * @throws DataBuilderFrameworkException
      */
-    public DataBuilderMetadataManager register(DataBuilderMeta dataBuilderMeta, Class<? extends DataBuilder> dataBuilder) throws DataBuilderFrameworkException {
-        return register(dataBuilderMeta.getConsumes(), dataBuilderMeta.getOptionals(), dataBuilderMeta.getAccess(), dataBuilderMeta.getProduces(), dataBuilderMeta.getName(), dataBuilder);
+    public DataBuilderMetadataManager register(
+            DataBuilderMeta dataBuilderMeta,
+            Class<? extends DataBuilder> dataBuilder) throws DataBuilderFrameworkException {
+        return register(dataBuilderMeta.getConsumes(),
+                        dataBuilderMeta.getOptionals(),
+                        dataBuilderMeta.getAccess(),
+                        dataBuilderMeta.getProduces(),
+                        dataBuilderMeta.getName(),
+                        dataBuilder);
     }
 
     /**
      * Register metadata for a {@link DataBuilder} implementation.
-     * @param consumes List of {@link io.appform.databuilderframework.model.Data} this builder consumes
-     * @param produces {@link io.appform.databuilderframework.model.Data} produced by this builder
-     * @param builder Name for this builder. there is no namespacing. Name needs to be unique
+     *
+     * @param consumes    List of {@link io.appform.databuilderframework.model.Data} this builder consumes
+     * @param produces    {@link io.appform.databuilderframework.model.Data} produced by this builder
+     * @param builder     Name for this builder. there is no namespacing. Name needs to be unique
      * @param dataBuilder The class of the builder to be created
      * @throws DataBuilderFrameworkException In case of name conflict
      */
-    public DataBuilderMetadataManager register(Set<String> consumes, String produces,
-                         String builder, Class<? extends DataBuilder> dataBuilder) throws DataBuilderFrameworkException {
+    public DataBuilderMetadataManager register(
+            Set<String> consumes, String produces,
+            String builder, Class<? extends DataBuilder> dataBuilder) throws DataBuilderFrameworkException {
         return register(consumes, null, null, produces, builder, dataBuilder);
     }
 
-    public DataBuilderMetadataManager registerWithOptionals(Set<String> consumes, Set<String> optionals, String produces,
+    public DataBuilderMetadataManager registerWithOptionals(
+            Set<String> consumes, Set<String> optionals, String produces,
             String builder, Class<? extends DataBuilder> dataBuilder) throws DataBuilderFrameworkException {
         return register(consumes, optionals, null, produces, builder, dataBuilder);
-        }
-    
-    public DataBuilderMetadataManager registerWithAccess(Set<String> consumes, Set<String> access, String produces,
+    }
+
+    public DataBuilderMetadataManager registerWithAccess(
+            Set<String> consumes, Set<String> access, String produces,
             String builder, Class<? extends DataBuilder> dataBuilder) throws DataBuilderFrameworkException {
         return register(consumes, null, access, produces, builder, dataBuilder);
     }
-    
-    public DataBuilderMetadataManager register(Set<String> consumes, Set<String> optionals, Set<String> access, String produces,
+
+    public DataBuilderMetadataManager register(
+            Set<String> consumes, Set<String> optionals, Set<String> access, String produces,
             String builder, Class<? extends DataBuilder> dataBuilder) throws DataBuilderFrameworkException {
-        DataBuilderMeta metadata = new DataBuilderMeta(consumes, produces, builder, optionals, access);
-        if(meta.containsKey(builder)) {
+        if (meta.containsKey(builder)) {
             throw new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.BUILDER_EXISTS,
-                    "A builder with name " + builder + " already exists");
+                                                    "A builder with name " + builder + " already exists");
         }
+        val metadata = new DataBuilderMeta(consumes, produces, builder, optionals, access);
         meta.put(builder, metadata);
-        if(!producedToProducerMap.containsKey(produces)) {
-            producedToProducerMap.put(produces, Lists.<DataBuilderMeta>newArrayList());
+        producedToProducerMap
+                .computeIfAbsent(produces, k -> new ArrayList<>())
+                .add(metadata);
+        consumes.forEach(
+                consumesData -> consumesMeta.computeIfAbsent(consumesData, k -> new TreeSet<>()).add(metadata));
+
+        if (optionals != null) {
+            optionals.forEach(
+                    optionalsData -> optionalsMeta.computeIfAbsent(optionalsData, k -> new TreeSet<>()).add(metadata));
         }
-        producedToProducerMap.get(produces).add(metadata);
-        for(String consumesData : consumes) {
-            if(!consumesMeta.containsKey(consumesData)) {
-                consumesMeta.put(consumesData, Sets.<DataBuilderMeta>newTreeSet());
-            }
-            consumesMeta.get(consumesData).add(metadata);
-        }
-        
-        if(optionals != null){
-            for(String optionalsData : optionals) {
-                if(!optionalsMeta.containsKey(optionalsData)) {
-                    optionalsMeta.put(optionalsData, Sets.<DataBuilderMeta>newTreeSet());
-                }
-                optionalsMeta.get(optionalsData).add(metadata);
-            }
-            
-        }
-        if(access != null){
-            for(String accessData : access) {
-                if(!accessesMeta.containsKey(accessData)) {
-                    accessesMeta.put(accessData, Sets.<DataBuilderMeta>newTreeSet());
-                }
-                accessesMeta.get(accessData).add(metadata);
-            }
+        if (access != null) {
+            access.forEach(
+                    accessData -> accessesMeta.computeIfAbsent(accessData, k -> new TreeSet<>()).add(metadata));
         }
         dataBuilders.put(builder, dataBuilder);
         return this;
     }
-    
+
     /**
      * Get {@link io.appform.databuilderframework.model.DataBuilderMeta} meta for all builders that consume this data.
+     *
      * @param data Name of the data to be consumed
      * @return Set of {@link io.appform.databuilderframework.model.DataBuilderMeta} for matching builders
-     *         or null if none found
+     * or null if none found
      */
     public Set<DataBuilderMeta> getConsumesSetFor(final String data) {
         return consumesMeta.get(data);
@@ -139,9 +134,10 @@ public class DataBuilderMetadataManager {
 
     /**
      * Get {@link io.appform.databuilderframework.model.DataBuilderMeta} for builder that produces this data
+     *
      * @param data Data being produced
      * @return List of {@link io.appform.databuilderframework.model.DataBuilderMeta} that are capable of
-     *         producing this data or null if not found.
+     * producing this data or null if not found.
      */
     public List<DataBuilderMeta> getMetaForProducerOf(final String data) {
         return producedToProducerMap.get(data);
@@ -149,6 +145,7 @@ public class DataBuilderMetadataManager {
 
     /**
      * Get {@link io.appform.databuilderframework.model.DataBuilderMeta} for a particular builder.
+     *
      * @param builderName Name of the builder
      * @return Meta if found, null otherwise
      */
@@ -158,6 +155,7 @@ public class DataBuilderMetadataManager {
 
     /**
      * Get all {@link io.appform.databuilderframework.model.DataBuilderMeta} for the for the provided names.
+     *
      * @param builderNames List of data builder names
      * @return List of builder metadata
      */
@@ -171,6 +169,7 @@ public class DataBuilderMetadataManager {
 
     /**
      * Get a derived class of {@link DataBuilder} for the given name.
+     *
      * @param builderName Name of the builder
      * @return Class if found, null otherwise
      */
@@ -180,11 +179,11 @@ public class DataBuilderMetadataManager {
 
     public DataBuilderMetadataManager immutableCopy() {
         return new DataBuilderMetadataManager(ImmutableMap.copyOf(dataBuilders),
-                
-                ImmutableMap.copyOf(meta),
-                ImmutableMap.copyOf(producedToProducerMap),
-                ImmutableMap.copyOf(consumesMeta),
-                ImmutableMap.copyOf(optionalsMeta),
-                ImmutableMap.copyOf(accessesMeta));
+
+                                              ImmutableMap.copyOf(meta),
+                                              ImmutableMap.copyOf(producedToProducerMap),
+                                              ImmutableMap.copyOf(consumesMeta),
+                                              ImmutableMap.copyOf(optionalsMeta),
+                                              ImmutableMap.copyOf(accessesMeta));
     }
 }

--- a/src/main/java/io/appform/databuilderframework/engine/DataContainer.java
+++ b/src/main/java/io/appform/databuilderframework/engine/DataContainer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 $user
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appform.databuilderframework.engine;
+
+import io.appform.databuilderframework.model.Data;
+import io.appform.databuilderframework.model.DataBuilderMeta;
+import lombok.Value;
+
+/**
+ *
+ */
+@Value
+public class DataContainer {
+    DataBuilderMeta builderMeta;
+    Data generatedData;
+    boolean hasError;
+    DataBuilderFrameworkException exception;
+    DataValidationException validationException;
+
+    DataContainer(DataBuilderMeta builderMeta, Data generatedData) {
+        this(builderMeta, generatedData, false, null, null);
+    }
+
+    DataContainer(DataBuilderMeta builderMeta, DataBuilderFrameworkException exception) {
+        this(builderMeta, null, true, exception, null);
+
+    }
+
+    DataContainer(DataBuilderMeta builderMeta, DataValidationException validationException) {
+        this(builderMeta, null, true, null, validationException);
+    }
+
+
+    DataContainer(
+            DataBuilderMeta builderMeta,
+            Data generatedData,
+            boolean hasError,
+            DataBuilderFrameworkException exception,
+            DataValidationException validationException) {
+        this.builderMeta = builderMeta;
+        this.generatedData = generatedData;
+        this.hasError = hasError;
+        this.exception = exception;
+        this.validationException = validationException;
+    }
+}

--- a/src/main/java/io/appform/databuilderframework/engine/DataFlowBuilder.java
+++ b/src/main/java/io/appform/databuilderframework/engine/DataFlowBuilder.java
@@ -25,10 +25,11 @@ import java.util.stream.Collectors;
  *
  * <br>An object of this type should not be re-used.
  */
+@SuppressWarnings("unused")
 public class DataFlowBuilder {
     private DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
-    private DataFlow dataFlow = new DataFlow();
-    private MixedDataBuilderFactory dataBuilderFactory = new MixedDataBuilderFactory();
+    private final DataFlow dataFlow = new DataFlow();
+    private final MixedDataBuilderFactory dataBuilderFactory = new MixedDataBuilderFactory();
 
     public DataFlowBuilder() {
         dataFlow.setTransients(Sets.newHashSet());
@@ -37,7 +38,7 @@ public class DataFlowBuilder {
     /**
      * Set name for the data flow. This is optional but recommended.
      * @param name Name for the dataflow
-     * @return
+     * @return this builder
      */
     public DataFlowBuilder withName(final String name) {
         this.dataFlow.setName(name);
@@ -45,8 +46,8 @@ public class DataFlowBuilder {
     }
     /**
      * Register your own metadata manager. This comes in handy if you want to manage DataBuilder metadata yourself.
-     * @param dataBuilderMetadataManager
-     * @return
+     * @param dataBuilderMetadataManager Meta manager to use
+     * @return this builder
      */
     public DataFlowBuilder withMetaDataManager(DataBuilderMetadataManager dataBuilderMetadataManager) {
         this.dataBuilderMetadataManager = dataBuilderMetadataManager;
@@ -58,8 +59,8 @@ public class DataFlowBuilder {
      * @param produces Name of the data that this builder produces.
      * @param consumes Names of the data that this class consumes.
      * @param dataBuilder Builder class to be used. Class must have a no-args constructor.
-     * @return
-     * @throws DataBuilderFrameworkException
+     * @return this builder
+     * @throws DataBuilderFrameworkException if builder could not be instantiated
      */
     public DataFlowBuilder withDataBuilder(String produces,
                                            Set<String> consumes,
@@ -72,8 +73,8 @@ public class DataFlowBuilder {
      * @param produces Name of the data that this builder produces.
      * @param consumes Names of the data that this class consumes.
      * @param dataBuilder Builder class to be used. Class must have a no-args constructor.
-     * @return
-     * @throws DataBuilderFrameworkException
+     * @return this builder
+     * @throws DataBuilderFrameworkException if builder could not be instantiated
      */
     public DataFlowBuilder withDataBuilder(String name,
                                            String produces,
@@ -88,8 +89,8 @@ public class DataFlowBuilder {
      * @param consumes Names of the data that this class consumes.
      * @param dataBuilder Builder class to be used. Class must have a no-args constructor.
      * @param isTransient Data produced by this class is transient and will not be a part of the data-set.
-     * @return
-     * @throws DataBuilderFrameworkException
+     * @return this builder
+     * @throws DataBuilderFrameworkException if builder could not be instantiated
      */
     public DataFlowBuilder withDataBuilder(String name,
                                            String produces,
@@ -105,8 +106,8 @@ public class DataFlowBuilder {
 
     /**
      * Register a builder class annotated with either {@link io.appform.databuilderframework.annotations.DataBuilderInfo} or {@link io.appform.databuilderframework.annotations.DataBuilderClassInfo}
-     * @return
-     * @throws DataBuilderFrameworkException
+     * @return this builder
+     * @throws DataBuilderFrameworkException if builder could not be instantiated
      */
 
     public DataFlowBuilder withAnnotatedDataBuilder(Class<? extends DataBuilder> annotatedDataBuilder) throws DataBuilderFrameworkException {
@@ -119,8 +120,8 @@ public class DataFlowBuilder {
      * @param produces Name of the data that this builder produces.
      * @param consumes Names of the data that this builder consumes.
      * @param dataBuilder Builder class to be used.
-     * @return
-     * @throws DataBuilderFrameworkException
+     * @return this builder
+     * @throws DataBuilderFrameworkException if builder could not be instantiated
      */
     public DataFlowBuilder withDataBuilder(String produces,
                                            Set<String> consumes,
@@ -133,8 +134,8 @@ public class DataFlowBuilder {
      * @param produces Name of the data that this builder produces.
      * @param consumes Names of the data that this builder consumes.
      * @param dataBuilder Builder class to be used.
-     * @return
-     * @throws DataBuilderFrameworkException
+     * @return this builder
+     * @throws DataBuilderFrameworkException if builder could not be instantiated
      */
     public DataFlowBuilder withDataBuilder(String name,
                                            String produces,
@@ -149,8 +150,8 @@ public class DataFlowBuilder {
      * @param consumes Names of the data that this builder consumes.
      * @param dataBuilder Builder class to be used.
      * @param isTransient Data produced by this class is transient and will not be a part of the data-set.
-     * @return
-     * @throws DataBuilderFrameworkException
+     * @return this builder
+     * @throws DataBuilderFrameworkException if builder could not be instantiated
      */
     public DataFlowBuilder withDataBuilder(String name,
                                            String produces,
@@ -170,8 +171,8 @@ public class DataFlowBuilder {
      * Regsiter an instance of a builder annotated with either {@link io.appform.databuilderframework.annotations.DataBuilderInfo}
      * or {@link io.appform.databuilderframework.annotations.DataBuilderClassInfo}
      * @param dataBuilder Builder instance
-     * @return
-     * @throws DataBuilderFrameworkException
+     * @return this builder
+     * @throws DataBuilderFrameworkException if builder could not be instantiated
      */
     public DataFlowBuilder withDataBuilder(DataBuilder dataBuilder) throws DataBuilderFrameworkException {
         Preconditions.checkNotNull(dataBuilder, "Null DataBuilder cannot be registered");
@@ -186,7 +187,7 @@ public class DataFlowBuilder {
     /**
      * The data to be generated. The build method will use this to create the execution graph.
      * @param targetDataClass Class name for the data to be generated.
-     * @return
+     * @return this builder
      */
     public DataFlowBuilder withTargetData(Class<? extends DataAdapter> targetDataClass) {
         this.dataFlow.setTargetData(Utils.name(targetDataClass));
@@ -196,7 +197,7 @@ public class DataFlowBuilder {
     /**
      * The data to be generated. The build method will use this to create the execution graph.
      * @param data Logical name for the data to be generated.
-     * @return
+     * @return this builder
      */
     public DataFlowBuilder withTargetData(String data) {
         this.dataFlow.setTargetData(data);
@@ -207,7 +208,7 @@ public class DataFlowBuilder {
      * Register a resolution spec to resolve conflicts in scenarios when multiple builders known to the system can generate the same required data.
      * @param data Data to be generated
      * @param generatingBuilder Name of the builder that will generate this data in the context of the flow being built
-     * @return
+     * @return this builder
      */
     public DataFlowBuilder withResolutionSpec(final String data, final String generatingBuilder) {
         this.dataFlow.getResolutionSpecs().put(data, generatingBuilder);
@@ -218,7 +219,7 @@ public class DataFlowBuilder {
      * Register a resolution spec to resolve conflicts in scenarios when multiple builders known to the system can generate the same required data.
      * @param data Data to be generated
      * @param generatingBuilder Name of the builder that will generate this data in the context of the flow being built
-     * @return
+     * @return this builder
      */
     public DataFlowBuilder withResolutionSpec(final Class<? extends Data> data, final Class<? extends DataBuilder> generatingBuilder) {
         this.dataFlow.getResolutionSpecs().put(Utils.name(data), Utils.name(generatingBuilder));
@@ -229,7 +230,7 @@ public class DataFlowBuilder {
      * Register a transient data
      *
      * @param data Name of transient data
-     * @return
+     * @return this builder
      */
     public DataFlowBuilder withTransientData(String data) {
         dataFlow.getTransients().add(data);
@@ -240,7 +241,7 @@ public class DataFlowBuilder {
      * Register a transient data by class name
      *
      * @param dataClass Class of the data. Name will be derived from this
-     * @return
+     * @return this builder
      */
     public DataFlowBuilder withTransientDataClass(Class<? extends Data> dataClass) {
         dataFlow.getTransients().add(Utils.name(dataClass));
@@ -251,7 +252,7 @@ public class DataFlowBuilder {
      * Register a transient data
      *
      * @param data Names of transient data
-     * @return
+     * @return this builder
      */
     public DataFlowBuilder withTransientData(Collection<String> data) {
         dataFlow.getTransients().addAll(data);
@@ -262,7 +263,7 @@ public class DataFlowBuilder {
      * Register a transient data by class name
      *
      * @param dataClasses Classes of the data. Name will be derived from this
-     * @return
+     * @return this builder
      */
     public DataFlowBuilder withTransientDataClasses(Collection<Class<? extends Data>> dataClasses) {
         dataFlow.getTransients().addAll(

--- a/src/main/java/io/appform/databuilderframework/engine/DataFlowExecutor.java
+++ b/src/main/java/io/appform/databuilderframework/engine/DataFlowExecutor.java
@@ -177,9 +177,11 @@ public abstract class DataFlowExecutor {
      * They will be called in order.
      *
      * @param listener Register a listener to be invoked during execution.
+     * @return The executor itself for chaining
      */
-    public void registerExecutionListener(DataBuilderExecutionListener listener) {
+    public DataFlowExecutor registerExecutionListener(DataBuilderExecutionListener listener) {
         dataBuilderExecutionListener.add(listener);
+        return this;
     }
 
     private void executePreListeners(

--- a/src/main/java/io/appform/databuilderframework/engine/DataSetAccessor.java
+++ b/src/main/java/io/appform/databuilderframework/engine/DataSetAccessor.java
@@ -82,7 +82,7 @@ public class DataSetAccessor {
     /**
      * Merge all {@link io.appform.databuilderframework.model.Data} elements from the {@link io.appform.databuilderframework.model.DataDelta}
      * Will overwrite all data present in the current {@link io.appform.databuilderframework.model.DataSet}.
-     * Each elemnt of data is identified using {@link Data#getData()}
+     * Each element of data is identified using Data::getData()
      *
      * @param dataDelta {@link io.appform.databuilderframework.model.DataDelta} to be merged
      */

--- a/src/main/java/io/appform/databuilderframework/engine/DataSetAccessor.java
+++ b/src/main/java/io/appform/databuilderframework/engine/DataSetAccessor.java
@@ -71,8 +71,7 @@ public class DataSetAccessor {
 
     /**
      * Merge data with current {@link io.appform.databuilderframework.model.DataSet}.
-     * Data will be added to the current data-set and override data with same type as identified by
-     * {@link io.appform.databuilderframework.model.Data#getData()}
+     * Data will be added to the current data-set and override data with same type
      *
      * @param data {@link io.appform.databuilderframework.model.Data} to be merged.
      */

--- a/src/main/java/io/appform/databuilderframework/engine/DataSetAccessor.java
+++ b/src/main/java/io/appform/databuilderframework/engine/DataSetAccessor.java
@@ -1,13 +1,13 @@
 package io.appform.databuilderframework.engine;
 
+import com.google.common.base.Preconditions;
 import io.appform.databuilderframework.model.Data;
 import io.appform.databuilderframework.model.DataDelta;
 import io.appform.databuilderframework.model.DataSet;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicates;
-import com.google.common.collect.Maps;
+import lombok.val;
 
-import java.util.Map;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Set;
 
 /**
@@ -16,7 +16,7 @@ import java.util.Set;
  */
 public class DataSetAccessor {
 
-    private DataSet dataSet;
+    private final DataSet dataSet;
 
     public DataSetAccessor(DataSet dataSet) {
         this.dataSet = dataSet;
@@ -28,23 +28,23 @@ public class DataSetAccessor {
 
     /**
      * Get a data from {@link io.appform.databuilderframework.model.DataSet}.
+     *
      * @param key    Key for the data
      * @param tClass Class to cast the data to. Should inherit from {@link io.appform.databuilderframework.model.Data}
      * @param <T>    Sub-Type for {@link io.appform.databuilderframework.model.Data}. Should be same as <i>tClass</i>
      * @return data
      */
     public <T extends Data> T get(String key, Class<T> tClass) {
-        Map<String, Data> availableData = dataSet.getAvailableData();
-        if (availableData.containsKey(key)) {
-            Data data = availableData.get(key);
-            return tClass.cast(data);
-        }
-        return null;
+        val data = dataSet.get(key);
+        return null == data
+               ? null
+               : tClass.cast(data);
     }
 
     /**
      * Get data from {@link io.appform.databuilderframework.model.DataSet}, with accessibility checks.
      * This will throw an exception if the calling data builder is not supposed to use the requested data.
+     *
      * @param key     Key for the data
      * @param builder {@link io.appform.databuilderframework.engine.DataBuilder} that is accessing the data
      * @param tClass  Class to cast the data to. Should inherit from {@link io.appform.databuilderframework.model.Data}
@@ -53,71 +53,72 @@ public class DataSetAccessor {
      */
     public <B extends DataBuilder, T extends Data> T getAccessibleData(String key, B builder, Class<T> tClass) {
         Preconditions.checkArgument(!builder.getDataBuilderMeta().getAccessibleDataSet().contains(key),
-                String.format("Builder %s can access only %s",
-                        builder.getDataBuilderMeta().getName(),
-                        builder.getDataBuilderMeta().getConsumes()));
+                                    String.format("Builder %s can access only %s",
+                                                  builder.getDataBuilderMeta().getName(),
+                                                  builder.getDataBuilderMeta().getConsumes()));
         return get(key, tClass);
     }
 
     /**
-     * Get only the accesible data for this builder.
+     * Get only the accessible data for this builder.
+     *
      * @param builder
      * @return
      */
     public DataSet getAccesibleDataSetFor(DataBuilder builder) {
-        return new DataSet(Maps.filterKeys(dataSet.getAvailableData(),
-                Predicates.in(builder.getDataBuilderMeta().getAccessibleDataSet())));
+        return new DataSet(dataSet.filter(builder.getDataBuilderMeta().getAccessibleDataSet()));
     }
 
     /**
      * Merge data with current {@link io.appform.databuilderframework.model.DataSet}.
      * Data will be added to the current data-set and override data with same type as identified by
      * {@link io.appform.databuilderframework.model.Data#getData()}
+     *
      * @param data {@link io.appform.databuilderframework.model.Data} to be merged.
      */
     public void merge(Data data) {
-        dataSet.getAvailableData().put(data.getData(), data);
+        dataSet.add(data.getData(), data);
     }
 
     /**
      * Merge all {@link io.appform.databuilderframework.model.Data} elements from the {@link io.appform.databuilderframework.model.DataDelta}
      * Will overwrite all data present in the current {@link io.appform.databuilderframework.model.DataSet}.
      * Each elemnt of data is identified using {@link Data#getData()}
+     *
      * @param dataDelta {@link io.appform.databuilderframework.model.DataDelta} to be merged
      */
     public void merge(DataDelta dataDelta) {
-        Map<String, Data> availableData = dataSet.getAvailableData();
-        for (Data data : dataDelta.getDelta()) {
-            availableData.put(data.getData(), data);
-        }
+        dataSet.add(dataDelta.getDelta());
     }
 
     /**
      * Check if all specified data is present in the {@link io.appform.databuilderframework.model.DataSet}
+     *
      * @param dataList List of all name of all data items to be checked.
      * @return <i>true</i> if all elements are present. <i>false</i> otherwise.
      */
     public boolean checkForData(Set<String> dataList) {
-        Map<String, Data> availableData = dataSet.getAvailableData();
-        return availableData.keySet().containsAll(dataList);
+        return dataSet.containsAll(dataList);
     }
 
     /**
      * Check if a specified data is present in the {@link io.appform.databuilderframework.model.DataSet}
+     *
      * @param data Name of the data items to be checked.
      * @return <i>true</i> if all elements are present. <i>false</i> otherwise.
      */
     public boolean checkForData(String data) {
-        return dataSet.getAvailableData().containsKey(data);
+        return dataSet.containsAll(Collections.singleton(data));
     }
 
     /**
      * Check if a specified data is present in the {@link io.appform.databuilderframework.model.DataSet}
+     *
      * @param clazz Class to be checked.
      * @return <i>true</i> if all elements are present. <i>false</i> otherwise.
      */
     public boolean checkForData(Class<?> clazz) {
-        return dataSet.getAvailableData().containsKey(Utils.name(clazz));
+        return checkForData(Utils.name(clazz));
     }
 
     /**
@@ -131,12 +132,8 @@ public class DataSetAccessor {
      * Get a copy of the underlying data set. Don't copy transients.
      */
     public DataSet copy(Set<String> transients) {
-        Map<String, Data> dataMap = Maps.newHashMap();
-        if (null != transients && !transients.isEmpty()) {
-            dataMap.putAll(Maps.filterKeys(dataSet.getAvailableData(), Predicates.not(Predicates.in(transients))));
-        } else {
-            dataMap.putAll(dataSet.getAvailableData());
-        }
+        val dataMap = new HashMap<String, Data>();
+        dataSet.copyInto(dataMap, transients);
         return new DataSet(dataMap);
     }
 }

--- a/src/main/java/io/appform/databuilderframework/engine/DataValidationException.java
+++ b/src/main/java/io/appform/databuilderframework/engine/DataValidationException.java
@@ -1,69 +1,59 @@
 package io.appform.databuilderframework.engine;
 
 import io.appform.databuilderframework.model.DataExecutionResponse;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.Value;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
  * Created by kaustav.das on 26/03/15.
  */
+@Value
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class DataValidationException extends Exception {
-    private Map<String,Object> details;
-    private DataExecutionResponse response;
     public enum ErrorCode {
         DATA_VALIDATION_EXCEPTION
     }
 
-    private final ErrorCode errorCode;
+    ErrorCode errorCode;
+    Map<String, Object> details;
+    DataExecutionResponse response;
+
 
 
     public DataValidationException(String message) {
-        super(message);
-        this.errorCode = ErrorCode.DATA_VALIDATION_EXCEPTION;
+        this(ErrorCode.DATA_VALIDATION_EXCEPTION, message);
     }
 
     public DataValidationException(ErrorCode errorCode, String message) {
-        super(message);
-        this.errorCode = errorCode;
+        this(errorCode, message, Collections.emptyMap());
     }
 
     public DataValidationException(ErrorCode errorCode, String message, Throwable cause) {
-        super(message, cause);
-        this.errorCode = errorCode;
+        this(errorCode, message, Collections.emptyMap(), cause);
     }
 
     public DataValidationException(ErrorCode errorCode, String message, Map<String, Object> details) {
-        super(message);
-        this.details=details;
-        this.errorCode = errorCode;
+        this(errorCode, message, details, null);
     }
 
     public DataValidationException(ErrorCode errorCode, String message, Map<String, Object> details, Throwable cause) {
+        this(errorCode, message, null, details, cause);
+    }
+
+    public DataValidationException(
+            ErrorCode errorCode,
+            String message,
+            DataExecutionResponse response,
+            Map<String, Object> details,
+            Throwable cause) {
         super(message, cause);
-        this.details=details;
+        this.details = details;
         this.errorCode = errorCode;
-    }
-
-    public DataValidationException(ErrorCode errorCode, String message, DataExecutionResponse response, Map<String, Object> details, Throwable cause) {
-        super(message, cause);
-        this.details=details;
-        this.errorCode = errorCode;
-        this.response = response;
-    }
-
-    public Map<String, Object> getDetails() {
-        return details;
-    }
-
-    public ErrorCode getErrorCode() {
-        return errorCode;
-    }
-
-    public DataExecutionResponse getResponse() {
-        return response;
-    }
-
-    public void setResponse(DataExecutionResponse response) {
         this.response = response;
     }
 }

--- a/src/main/java/io/appform/databuilderframework/engine/ExecutionGraphGenerator.java
+++ b/src/main/java/io/appform/databuilderframework/engine/ExecutionGraphGenerator.java
@@ -1,16 +1,16 @@
 package io.appform.databuilderframework.engine;
 
+import com.google.common.collect.Maps;
 import io.appform.databuilderframework.engine.util.TimedExecutor;
 import io.appform.databuilderframework.model.DataBuilderMeta;
 import io.appform.databuilderframework.model.DataFlow;
 import io.appform.databuilderframework.model.ExecutionGraph;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This class generates an {@link io.appform.databuilderframework.model.ExecutionGraph}.
@@ -20,7 +20,7 @@ import java.util.*;
  */
 @Slf4j
 public class ExecutionGraphGenerator {
-    private DataBuilderMetadataManager dataBuilderMetadataManager;
+    private final DataBuilderMetadataManager dataBuilderMetadataManager;
 
     public ExecutionGraphGenerator(DataBuilderMetadataManager dataBuilderMetadataManager) {
         this.dataBuilderMetadataManager = dataBuilderMetadataManager;
@@ -30,31 +30,33 @@ public class ExecutionGraphGenerator {
      * Generates an {@link io.appform.databuilderframework.model.ExecutionGraph} for the given graph.
      * An exception is thrown if not target is specified, or there are multiple builders for the same data, but no
      * resolution is provided for the same(conflict).
+     *
      * @param dataFlow The {@link io.appform.databuilderframework.model.DataFlow} object to be analyzed
      * @return Returns the ExecutionGraph
      * @throws DataBuilderFrameworkException
      */
     public ExecutionGraph generateGraph(final DataFlow dataFlow) throws DataBuilderFrameworkException {
-        if(dataFlow.getTargetData() == null || dataFlow.getTargetData().isEmpty()) {
-            throw new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.NO_TARGET_DATA,
-                                                                    "No target data specified for flow");
+        if (dataFlow.getTargetData() == null || dataFlow.getTargetData().isEmpty()) {
+            throw new DataBuilderFrameworkException(
+                    DataBuilderFrameworkException.ErrorCode.NO_TARGET_DATA, "No target data specified for flow");
         }
-        DependencyInfoManager dependencyInfoManager = new DependencyInfoManager();
+        val dependencyInfoManager = new DependencyInfoManager();
 
-        /**
+        /*
          * STEP 1:: GENERATE DEPENDENCY TREE {ROOT=>TARGET}
          */
-        DependencyNode root
+        val root
                 = TimedExecutor.run("ExecutionGraphGenerator::generateDependencyTree",
-                                                () -> generateDependencyTree(dataFlow.getTargetData(), dataFlow, null,
-                                                                   new DependencyNodeManager(), dependencyInfoManager,
-                                                                   new FlattenedDataRoute()));
-        /**
+                                    () -> generateDependencyTree(dataFlow.getTargetData(), dataFlow, null,
+                                                                 new DependencyNodeManager(), dependencyInfoManager,
+                                                                 new FlattenedDataRoute()));
+        /*
          * STEP 2:: RANK NODES IN THE TREE ACCORDING TO DISTANCE FROM ROOT
          */
-        int maxHeight = TimedExecutor.run("ExecutionGraphGenerator::rankNodes", () -> rankNodes(root, 0, Sets.newHashSet()));
+        val maxHeight = TimedExecutor.run("ExecutionGraphGenerator::rankNodes",
+                                          () -> rankNodes(root, 0, new HashSet<>()));
 
-        /**
+        /*
         STEP 3:: CREATE REPRESENTATION
         Representation : Example of a three level tree:
             A
@@ -76,37 +78,35 @@ public class ExecutionGraphGenerator {
            2 : [A]
         ]
         */
-        List<List<DataBuilderMeta>> dependencyHierarchy
-                = TimedExecutor.run("ExecutionGraphGenerator::buildHierarchy", () -> buildHierarchy(dependencyInfoManager, maxHeight));
+        val dependencyHierarchy
+                = TimedExecutor.run("ExecutionGraphGenerator::buildHierarchy",
+                                    () -> buildHierarchy(dependencyInfoManager, maxHeight));
 
         //Return
         return new ExecutionGraph(dependencyHierarchy);
     }
 
     private List<List<DataBuilderMeta>> buildHierarchy(
-            DependencyInfoManager dependencyInfoManager,
-            int maxHeight) {
+            DependencyInfoManager dependencyInfoManager, int maxHeight) {
         Map<String, DependencyInfo> dependencyInfos = dependencyInfoManager.infos;
 
         //Fill up array with nulls. Array size == max Rank
-        List<List<DataBuilderMeta>> dependencyHierarchy
-                                        = new ArrayList<>(Collections.nCopies(maxHeight + 1, null));
+        val dependencyHierarchy = new ArrayList<List<DataBuilderMeta>>(Collections.nCopies(maxHeight + 1, null));
 
         //For each dependency
-        for(Map.Entry<String, DependencyInfo> dependencyInfo : dependencyInfos.entrySet()) {
+        for (Map.Entry<String, DependencyInfo> dependencyInfo : dependencyInfos.entrySet()) {
             DataBuilderMeta tmpDataBuilderMeta
-                                = dataBuilderMetadataManager.get(dependencyInfo.getValue().getBuilder());
-            if(null == tmpDataBuilderMeta) {
+                    = dataBuilderMetadataManager.get(dependencyInfo.getValue().getBuilder());
+            if (null == tmpDataBuilderMeta) {
                 //Data is user-input data
                 continue;
             }
-            DataBuilderMeta dataBuilderMeta = tmpDataBuilderMeta.deepCopy();
-            int rank = dependencyInfo.getValue().getRank();
-            dataBuilderMeta.setRank(rank);
+            val rank = dependencyInfo.getValue().getRank();
+            val dataBuilderMeta = tmpDataBuilderMeta.deepCopy().setRank(rank);
 
             //Set builder in the appropriate rank slots
-            if(null == dependencyHierarchy.get(rank)) {
-                dependencyHierarchy.set(rank, Lists.<DataBuilderMeta>newArrayList());
+            if (null == dependencyHierarchy.get(rank)) {
+                dependencyHierarchy.set(rank, new ArrayList<>());
             }
             dependencyHierarchy.get(rank).add(dataBuilderMeta);
         }
@@ -121,61 +121,60 @@ public class ExecutionGraphGenerator {
     }
 
     private int rankNodes(DependencyNode root, int currentNode, Set<String> processedNodes) {
-        String data = root.getData().getData();
+        val data = root.getData().getData();
 
-        if(root.getData().getRank() >= currentNode && processedNodes.contains(data)) {
+        val currRank = root.getData().getRank();
+        if (currRank >= currentNode && processedNodes.contains(data)) {
             return currentNode;
         }
 
-        if(root.getData().getRank() < currentNode) {
+        if (currRank < currentNode) {
             root.getData().setRank(currentNode);
         }
 
-        int childNode = currentNode + 1;
-        int returnValue = childNode;
-        for(DependencyNode child : root.getIncoming()) {
-            int val = rankNodes(child, childNode, processedNodes);
-            returnValue = Math.max(val, returnValue);
-        }
-        processedNodes.add(data);
-        return returnValue;
+        val childNode = currentNode + 1;
+        return root.getIncoming()
+                .stream()
+                .mapToInt(child -> Math.max(rankNodes(child, childNode, processedNodes), childNode))
+                .max()
+                .orElse(childNode);
     }
 
-    private DependencyNode generateDependencyTree(final String data, DataFlow dataFlow,
-                                                  DependencyInfo outgoing,
-                                                  DependencyNodeManager dependencyNodeManager,
-                                                  DependencyInfoManager dependencyInfoManager,
-                                                  FlattenedDataRoute routeMeta) throws DataBuilderFrameworkException {
-        DependencyNode root = dependencyNodeManager.get(data);
-        if(root.getData() != null ) {
+    private DependencyNode generateDependencyTree(
+            final String data, DataFlow dataFlow,
+            DependencyInfo outgoing,
+            DependencyNodeManager dependencyNodeManager,
+            DependencyInfoManager dependencyInfoManager,
+            FlattenedDataRoute routeMeta) throws DataBuilderFrameworkException {
+        val root = dependencyNodeManager.get(data);
+        if (root.getData() != null) {
             log.debug("Precomputed dependency tree found for data: {}", data);
             return root;
         }
         log.debug("Generating dependency tree for: {}", data);
-        List<DependencyNode> incoming = Lists.newArrayList();
-        DataBuilderMeta dataBuilderMeta = findBuilder(data, dataFlow);
-        DependencyInfo info = dependencyInfoManager.get(data);
-        if(null == info.getData()) {
+        val incoming = new ArrayList<DependencyNode>();
+        val dataBuilderMeta = findBuilder(data, dataFlow);
+        val info = dependencyInfoManager.get(data);
+        if (null == info.getData()) {
             info.setData(data);
         }
-        if(null != dataBuilderMeta) {
-            if(null == info.getBuilder()) {
+        if (null != dataBuilderMeta) {
+            if (null == info.getBuilder()) {
                 info.setBuilder(dataBuilderMeta.getName());
             }
-            for(String consumes : dataBuilderMeta.getEffectiveConsumes()) {
-                if(routeMeta.isAlreadyOnOutgoingPath(data, consumes)) {
+            for (String consumes : dataBuilderMeta.getEffectiveConsumes()) {
+                if (routeMeta.isAlreadyOnOutgoingPath(data, consumes)) {
                     log.warn("Loop detected: Path for {} already contains {}", consumes, data);
                     continue;
                 }
                 routeMeta.addOutputData(consumes, data);
-                DependencyNode childnode = generateDependencyTree(consumes, dataFlow, info,
-                                                dependencyNodeManager, dependencyInfoManager, routeMeta);
-                incoming.add(childnode);
+                incoming.add(generateDependencyTree(consumes, dataFlow, info,
+                                                    dependencyNodeManager, dependencyInfoManager, routeMeta));
             }
         }
         root.setData(info);
         root.setIncoming(incoming);
-        if(null != outgoing) {
+        if (null != outgoing) {
             root.getOutgoing().add(outgoing);
         }
 
@@ -183,50 +182,44 @@ public class ExecutionGraphGenerator {
     }
 
     private DataBuilderMeta findBuilder(String data, DataFlow dataFlow) throws DataBuilderFrameworkException {
-        Map<String, String> resolutionSpecs = dataFlow.getResolutionSpecs();
-        DataBuilderMeta producerMeta = null;
-        if(null != resolutionSpecs && resolutionSpecs.containsKey(data)) {
-            producerMeta = dataBuilderMetadataManager.get(resolutionSpecs.get(data));
-            if(null == producerMeta) {
+        val resolutionSpecs = dataFlow.getResolutionSpecs();
+        if (null != resolutionSpecs && resolutionSpecs.containsKey(data)) {
+            val producerMeta = dataBuilderMetadataManager.get(resolutionSpecs.get(data));
+            if (null == producerMeta) {
                 //A resolution spec was specified but no builder was found
                 throw new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.NO_BUILDER_FOR_DATA,
-                        "No builder found with name: " + resolutionSpecs.get(data));
+                                                        "No builder found with name: " + resolutionSpecs.get(data));
             }
-            //log.info("Found builder for data " + data + ": " + resolutionSpecs.get(data));
+            return producerMeta;
         }
-        if(null == producerMeta) {
-            List<DataBuilderMeta> producerMetaList = dataBuilderMetadataManager.getMetaForProducerOf(data);
-            if(producerMetaList == null) {
-                log.debug("Starting data point found: {}", data);
-                return null;
-            }
+        val producerMetaList = dataBuilderMetadataManager.getMetaForProducerOf(data);
+        if (producerMetaList == null) {
+            log.debug("Starting data point found: {}", data);
+            return null;
+        }
 
-            if(producerMetaList.size() > 1) {
-                //No resolution spec was specified, but multiple builders were found
-                log.error("Multiple builders found for data, but no resolution spec found. Cannot proceed. data: {}", data);
-                throw new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.BUILDER_RESOLUTION_CONFLICT_FOR_DATA,
-                        "Multiple builders found for data, but no resolution spec found. Cannot proceed. Data: " + data);
-            }
-            producerMeta = producerMetaList.get(0);
+        if (producerMetaList.size() > 1) {
+            //No resolution spec was specified, but multiple builders were found
+            log.error("Multiple builders found for data, but no resolution spec found. Cannot proceed. data: {}", data);
+            throw new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.BUILDER_RESOLUTION_CONFLICT_FOR_DATA,
+                                                    "Multiple builders found for data, but no resolution spec found. Cannot proceed. Data: " + data);
         }
-        return producerMeta;
+        return producerMetaList.get(0);
     }
 
     private static class FlattenedDataRoute {
-        private Map<String, Set<String>> outgoingMap = Maps.newHashMap();
+        private final Map<String, Set<String>> outgoingMap = new ConcurrentHashMap<>();
 
         public void addOutputData(String input, String output) {
-            if(!outgoingMap.containsKey(input)) {
-                outgoingMap.put(input, Sets.<String>newHashSet());
-            }
-            outgoingMap.get(input).add(output);
-            if(outgoingMap.containsKey(output)) {
+            outgoingMap.computeIfAbsent(input, k -> new HashSet<>())
+                    .add(input);
+            if (outgoingMap.containsKey(output)) {
                 outgoingMap.get(input).addAll(outgoingMap.get(output)); //My output's outputs are my outputs also
             }
         }
 
         public boolean isAlreadyOnOutgoingPath(String input, String output) {
-            if(!outgoingMap.containsKey(input)) {
+            if (!outgoingMap.containsKey(input)) {
                 return false;
             }
             return outgoingMap.get(input).contains(output);
@@ -241,31 +234,25 @@ public class ExecutionGraphGenerator {
     }
 
     private static final class DependencyInfoManager {
-        private Map<String, DependencyInfo> infos = Maps.newHashMap();
+        private final Map<String, DependencyInfo> infos = new ConcurrentHashMap<>();
+
         DependencyInfo get(String data) {
-            if(!infos.containsKey(data)) {
-                infos.put(data,new DependencyInfo());
-            }
-            return infos.get(data);
+            return infos.computeIfAbsent(data, k -> new DependencyInfo());
         }
     }
 
     @Data
     private static class DependencyNode {
         private DependencyInfo data;
-        private List<DependencyNode> incoming = Lists.newArrayList();
-        private Set<DependencyInfo> outgoing = Sets.newLinkedHashSet();
+        private List<DependencyNode> incoming = new ArrayList<>();
+        private Set<DependencyInfo> outgoing = new LinkedHashSet<>();
     }
 
     private static class DependencyNodeManager {
-        private Map<String, DependencyNode> dataList = Maps.newHashMap();
+        private final Map<String, DependencyNode> dataList = Maps.newHashMap();
 
         DependencyNode get(String data) {
-            if(!dataList.containsKey(data)) {
-                dataList.put(data, new DependencyNode());
-            }
-            return dataList.get(data);
+            return dataList.computeIfAbsent(data, k -> new DependencyNode());
         }
-
     }
 }

--- a/src/main/java/io/appform/databuilderframework/engine/MultiThreadedDataFlowExecutor.java
+++ b/src/main/java/io/appform/databuilderframework/engine/MultiThreadedDataFlowExecutor.java
@@ -1,21 +1,25 @@
 package io.appform.databuilderframework.engine;
 
-import io.appform.databuilderframework.model.*;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.appform.databuilderframework.model.*;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 
 import java.util.*;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 /**
  * The executor for a {@link io.appform.databuilderframework.model.DataFlow}.
  */
+@Slf4j
+@SuppressWarnings("java:S1181")
 public class MultiThreadedDataFlowExecutor extends DataFlowExecutor {
-    private static final Logger logger = LoggerFactory.getLogger(MultiThreadedDataFlowExecutor.class.getSimpleName());
+
     private final ExecutorService executorService;
 
     public MultiThreadedDataFlowExecutor(ExecutorService executorService) {
@@ -31,265 +35,137 @@ public class MultiThreadedDataFlowExecutor extends DataFlowExecutor {
      * {@inheritDoc}
      */
     @Override
-    protected DataExecutionResponse run(DataBuilderContext dataBuilderContext,
-                                        DataFlowInstance dataFlowInstance,
-                                        DataDelta dataDelta,
-                                        DataFlow dataFlow,
-                                        DataBuilderFactory builderFactory) throws DataBuilderFrameworkException, DataValidationException {
-        CompletionService<DataContainer> completionExecutor = new ExecutorCompletionService<DataContainer>(executorService);
-        ExecutionGraph executionGraph = dataFlow.getExecutionGraph();
-        DataSet dataSet = dataFlowInstance.getDataSet().accessor().copy(); //Create own copy to work with
-        DataSetAccessor dataSetAccessor = DataSet.accessor(dataSet);
-        dataSetAccessor.merge(dataDelta);
-        Map<String, Data> responseData = Maps.newTreeMap();
-        Set<String> activeDataSet = Sets.newHashSet();
+    protected DataExecutionResponse run(
+            DataBuilderContext dataBuilderContext,
+            DataFlowInstance dataFlowInstance,
+            DataDelta dataDelta,
+            DataFlow dataFlow,
+            DataBuilderFactory builderFactory) throws DataBuilderFrameworkException, DataValidationException {
+        val completionExecutor = new ExecutorCompletionService<DataContainer>(executorService);
+        val executionGraph = dataFlow.getExecutionGraph();
+        val dataSet = dataFlowInstance.getDataSet().accessor().copy(); //Create own copy to work with
+        val dataSetAccessor = DataSet.accessor(dataSet);
+        val responseData = new TreeMap<String, Data>();
+        val activeDataSet = new HashSet<String>();
+        val dependencyHierarchy = executionGraph.getDependencyHierarchy();
+        val newlyGeneratedData = new HashSet<String>();
+        val processedBuilders = Collections.synchronizedSet(new HashSet<DataBuilderMeta>());
 
-        for (Data data : dataDelta.getDelta()) {
-            activeDataSet.add(data.getData());
-        }
-        List<List<DataBuilderMeta>> dependencyHierarchy = executionGraph.getDependencyHierarchy();
-        Set<String> newlyGeneratedData = Sets.newHashSet();
-        Set<DataBuilderMeta> processedBuilders = Collections.synchronizedSet(Sets.<DataBuilderMeta>newHashSet());
-        while(true) {
-            for (List<DataBuilderMeta> levelBuilders : dependencyHierarchy) {
-                List<Future<DataContainer>> dataFutures = Lists.newArrayList();
-                for (DataBuilderMeta builderMeta : levelBuilders) {
-                    if (processedBuilders.contains(builderMeta)) {
-                        continue;
-                    }
-                    //If there is an intersection, means some of it's inputs have changed. Reevaluate
-                    if (Sets.intersection(builderMeta.getEffectiveConsumes(), activeDataSet).isEmpty()) {
-                        continue;
-                    }
-                    DataBuilder builder = builderFactory.create(builderMeta);
-                    if (!dataSetAccessor.checkForData(builder.getDataBuilderMeta().getConsumes())) {
-                        continue;
-                    }
-                    BuilderRunner builderRunner = new BuilderRunner(dataBuilderExecutionListener, dataFlowInstance,
-                                                                        builderMeta, dataDelta, responseData,
-                                                                        builder, dataBuilderContext, processedBuilders, dataSet);
-                    Future<DataContainer> future = completionExecutor.submit(builderRunner);
-                    dataFutures.add(future);
-                }
+        dataSetAccessor.merge(dataDelta);
+        dataDelta.getDelta().forEach(data -> activeDataSet.add(data.getData()));
+
+        boolean completed = false;
+        while (!completed) {
+            for (val levelBuilders : dependencyHierarchy) {
+                List<Future<DataContainer>> dataFutures = startJobs(dataBuilderContext,
+                                                                    dataFlowInstance,
+                                                                    dataDelta,
+                                                                    builderFactory,
+                                                                    completionExecutor,
+                                                                    dataSet,
+                                                                    dataSetAccessor,
+                                                                    responseData,
+                                                                    activeDataSet,
+                                                                    processedBuilders,
+                                                                    levelBuilders);
+
 
                 //Now wait for something to complete.
-                int listSize = dataFutures.size();
-                for(int i = 0; i < listSize; i++) {
+                val listSize = dataFutures.size();
+                for (int i = 0; i < listSize; i++) {
                     try {
-                        DataContainer responseContainer = completionExecutor.take().get();
-                        Data response = responseContainer.getGeneratedData();
-                        String data = responseContainer.getBuilderMeta().getProduces();
-                        if(responseContainer.isHasError()) {
-                            if(null != responseContainer.getValidationException()) {
+                        val responseContainer = completionExecutor.take().get();
+                        val response = responseContainer.getGeneratedData();
+                        val data = responseContainer.getBuilderMeta().getProduces();
+                        if (responseContainer.isHasError()) {
+                            if (null != responseContainer.getValidationException()) {
                                 throw responseContainer.getValidationException();
-
                             }
 
                             throw responseContainer.getException();
                         }
                         if (null != response) {
                             Preconditions.checkArgument(response.getData().equalsIgnoreCase(data),
-                                    String.format("Builder is supposed to produce %s but produces %s",
-                                            data, response.getData()));
+                                                        String.format(
+                                                                "Builder is supposed to produce %s but produces %s",
+                                                                data,
+                                                                response.getData()));
                             dataSetAccessor.merge(response);
                             responseData.put(response.getData(), response);
                             activeDataSet.add(response.getData());
-                            if(null != dataFlow.getTransients() && !dataFlow.getTransients().contains(response.getData())) {
+                            if (null != dataFlow.getTransients() && !dataFlow.getTransients()
+                                    .contains(response.getData())) {
                                 newlyGeneratedData.add(response.getData());
                             }
                         }
                     }
                     catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
                         throw new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.BUILDER_EXECUTION_ERROR,
-                                "Error while waiting for error ", e);
-                    } catch (ExecutionException e) {
+                                                                "Error while waiting for error ", e);
+                    }
+                    catch (ExecutionException e) {
                         throw new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.BUILDER_EXECUTION_ERROR,
-                                "Error while waiting for error ", e.getCause());
+                                                                "Error while waiting for error ", e.getCause());
                     }
                 }
             }
-            if(newlyGeneratedData.contains(dataFlow.getTargetData())) {
-                //logger.debug("Finished running this instance of the flow. Exiting.");
-                break;
+            completed = newlyGeneratedData.contains(dataFlow.getTargetData())
+                    || newlyGeneratedData.isEmpty();
+            if (newlyGeneratedData.contains(dataFlow.getTargetData())) {
+                log.trace("Finished running this instance of the flow. Exiting.");
             }
-            if(newlyGeneratedData.isEmpty()) {
-                //logger.debug("Nothing happened in this loop, exiting..");
-                break;
+            if (newlyGeneratedData.isEmpty()) {
+                log.trace("Nothing happened in this loop, exiting..");
             }
-//            StringBuilder stringBuilder = new StringBuilder();
-//            for(String data : newlyGeneratedData) {
-//                stringBuilder.append(data + ", ");
-//            }
-            //logger.info("Newly generated: " + stringBuilder);
+            //Some data generated which is not the target. But we're done here
+            log.trace("Newly generated: {}", newlyGeneratedData);
             activeDataSet.clear();
             activeDataSet.addAll(newlyGeneratedData);
             newlyGeneratedData.clear();
-            if(!dataFlow.isLoopingEnabled()) {
-                break;
-            }
+            completed = completed || !dataFlow.isLoopingEnabled();
         }
         DataSet finalDataSet = dataSetAccessor.copy(dataFlow.getTransients());
         dataFlowInstance.setDataSet(finalDataSet);
         return new DataExecutionResponse(responseData);
     }
 
-    private static final class DataContainer {
-        private final DataBuilderMeta builderMeta;
-        private final Data generatedData;
-        private boolean hasError = false;
-        private final DataBuilderFrameworkException exception;
-        private final DataValidationException validationException;
-
-        private DataContainer(DataBuilderMeta builderMeta, Data generatedData) {
-            this.builderMeta = builderMeta;
-            this.generatedData = generatedData;
-            this.exception = null;
-            this.validationException = null;
-        }
-
-        private DataContainer(DataBuilderMeta builderMeta, DataBuilderFrameworkException exception) {
-            this.builderMeta = builderMeta;
-            this.generatedData = null;
-            this.hasError = true;
-            this.exception = exception;
-            this.validationException = null;
-        }
-
-        private DataContainer(DataBuilderMeta builderMeta, DataValidationException validationException) {
-            this.builderMeta = builderMeta;
-            this.generatedData = null;
-            this.hasError = true;
-            this.exception = null;
-            this.validationException = validationException;
-        }
-
-
-
-        public DataBuilderMeta getBuilderMeta() {
-            return builderMeta;
-        }
-
-        public Data getGeneratedData() {
-            return generatedData;
-        }
-
-        public DataBuilderFrameworkException getException() {
-            return exception;
-        }
-
-        public DataValidationException getValidationException() {
-            return validationException;
-        }
-
-        public boolean isHasError() {
-            return hasError;
-        }
+    @SuppressWarnings("java:S107")
+    private List<Future<DataContainer>> startJobs(
+            DataBuilderContext dataBuilderContext,
+            DataFlowInstance dataFlowInstance,
+            DataDelta dataDelta,
+            DataBuilderFactory builderFactory,
+            ExecutorCompletionService<DataContainer> completionExecutor,
+            DataSet dataSet,
+            DataSetAccessor dataSetAccessor,
+            TreeMap<String, Data> responseData,
+            HashSet<String> activeDataSet,
+            Set<DataBuilderMeta> processedBuilders,
+            List<DataBuilderMeta> levelBuilders) {
+        return levelBuilders.stream()
+                .filter(builderMeta -> !processedBuilders.contains(builderMeta)
+                        //If there is an intersection, means some of it's inputs have changed. Reevaluate
+                        && !Sets.intersection(builderMeta.getEffectiveConsumes(), activeDataSet).isEmpty())
+                .map(builderMeta -> {
+                    val builder = builderFactory.create(builderMeta);
+                    if (!dataSetAccessor.checkForData(builder.getDataBuilderMeta().getConsumes())) {
+                        return null;
+                    }
+                    return completionExecutor.submit(
+                            new BuilderRunner(dataBuilderExecutionListener,
+                                              dataFlowInstance,
+                                              dataDelta,
+                                              responseData,
+                                              builder,
+                                              builderMeta,
+                                              dataBuilderContext,
+                                              processedBuilders,
+                                              dataSet));
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
-    private static final class BuilderRunner implements Callable<DataContainer> {
 
-        private List<DataBuilderExecutionListener> dataBuilderExecutionListener;
-        private DataFlowInstance dataFlowInstance;
-        private DataBuilderMeta builderMeta;
-        private DataDelta dataDelta;
-        private Map<String,Data> responseData;
-        private DataBuilder builder;
-        private DataBuilderContext dataBuilderContext;
-        private final Set<DataBuilderMeta> procesedBuilders;
-        private DataSet dataSet;
-
-        private BuilderRunner(List<DataBuilderExecutionListener> dataBuilderExecutionListener,
-                              DataFlowInstance dataFlowInstance,
-                              DataBuilderMeta builderMeta,
-                              DataDelta dataDelta,
-                              Map<String, Data> responseData,
-                              DataBuilder builder,
-                              DataBuilderContext dataBuilderContext,
-                              Set<DataBuilderMeta> procesedBuilders,
-                              DataSet dataSet) {
-            this.dataBuilderExecutionListener = dataBuilderExecutionListener;
-            this.dataFlowInstance = dataFlowInstance;
-            this.builderMeta = builderMeta;
-            this.dataDelta = dataDelta;
-            this.responseData = responseData;
-            this.builder = builder;
-            this.dataBuilderContext = dataBuilderContext;
-            this.procesedBuilders = procesedBuilders;
-            this.dataSet = dataSet;
-        }
-
-        @Override
-        public DataContainer call() throws Exception {
-
-            for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
-                try {
-                    listener.beforeExecute(dataBuilderContext, dataFlowInstance, builderMeta, dataDelta, responseData);
-                } catch (Throwable t) {
-                    logger.error("Error running pre-execution execution listener: ", t);
-                }
-            }
-            try {
-                Data response = builder.process(dataBuilderContext.immutableCopy(
-                                            dataSet.accessor().getAccesibleDataSetFor(builder)));
-                //logger.debug("Ran " + builderMeta.getName());
-                procesedBuilders.add(builderMeta);
-                for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
-                    try {
-                        listener.afterExecute(dataBuilderContext, dataFlowInstance, builderMeta, dataDelta, responseData, response);
-                    } catch (Throwable t) {
-                        logger.error("Error running post-execution listener: ", t);
-                    }
-                }
-                if(null != response) {
-                    Preconditions.checkArgument(response.getData().equalsIgnoreCase(builderMeta.getProduces()),
-                            String.format("Builder is supposed to produce %s but produces %s",
-                                    builderMeta.getProduces(), response.getData()));
-                    response.setGeneratedBy(builderMeta.getName());
-                }
-                return new DataContainer(builderMeta, response);
-            } catch (DataBuilderException e) {
-                logger.error("Error running builder: " + builderMeta.getName());
-                for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
-                    try {
-                        listener.afterException(dataBuilderContext, dataFlowInstance, builderMeta, dataDelta, responseData, e);
-
-                    } catch (Throwable error) {
-                        logger.error("Error running post-execution listener: ", error);
-                    }
-                }
-                return new DataContainer(builderMeta, new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.BUILDER_EXECUTION_ERROR,
-                        "Error running builder: " + builderMeta.getName(), e.getDetails(), e));
-
-            } catch (DataValidationException e) {
-                logger.error("Validation error in data produced by builder" +builderMeta.getName());
-                for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
-                    try {
-                        listener.afterException(dataBuilderContext, dataFlowInstance, builderMeta, dataDelta, responseData, e);
-
-                    } catch (Throwable error) {
-                        logger.error("Error running post-execution listener: ", error);
-                    }
-                }
-                return new DataContainer(builderMeta, new DataValidationException(DataValidationException.ErrorCode.DATA_VALIDATION_EXCEPTION,
-                        "Error running builder: " + builderMeta.getName(), new DataExecutionResponse(responseData), e.getDetails(), e));
-
-
-            }
-            catch (Throwable t) {
-                logger.error("Error running builder: " + builderMeta.getName());
-                for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
-                    try {
-                        listener.afterException(dataBuilderContext, dataFlowInstance, builderMeta, dataDelta, responseData, t);
-
-                    } catch (Throwable error) {
-                        logger.error("Error running post-execution listener: ", error);
-                    }
-                }
-                Map<String, Object> objectMap = new HashMap<String, Object>();
-                objectMap.put("MESSAGE", t.getMessage());
-                return new DataContainer(builderMeta, new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.BUILDER_EXECUTION_ERROR,
-                        "Error running builder: " + builderMeta.getName() + t.getMessage(), objectMap, t));
-            }
-        }
-    }
 
 }

--- a/src/main/java/io/appform/databuilderframework/engine/OptimizedMultiThreadedDataFlowExecutor.java
+++ b/src/main/java/io/appform/databuilderframework/engine/OptimizedMultiThreadedDataFlowExecutor.java
@@ -1,13 +1,12 @@
 package io.appform.databuilderframework.engine;
 
-import io.appform.databuilderframework.model.*;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.appform.databuilderframework.model.*;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 
 import java.util.*;
 import java.util.concurrent.*;
@@ -15,15 +14,17 @@ import java.util.concurrent.*;
 /**
  * The executor for a {@link io.appform.databuilderframework.model.DataFlow}.
  */
+@Slf4j
 public class OptimizedMultiThreadedDataFlowExecutor extends DataFlowExecutor {
-    private static final Logger logger = LoggerFactory.getLogger(OptimizedMultiThreadedDataFlowExecutor.class.getSimpleName());
     private final ExecutorService executorService;
 
     public OptimizedMultiThreadedDataFlowExecutor(ExecutorService executorService) {
         this.executorService = executorService;
     }
 
-    public OptimizedMultiThreadedDataFlowExecutor(DataBuilderFactory dataBuilderFactory, ExecutorService executorService) {
+    public OptimizedMultiThreadedDataFlowExecutor(
+            DataBuilderFactory dataBuilderFactory,
+            ExecutorService executorService) {
         super(dataBuilderFactory);
         this.executorService = executorService;
     }
@@ -32,28 +33,28 @@ public class OptimizedMultiThreadedDataFlowExecutor extends DataFlowExecutor {
      * {@inheritDoc}
      */
     @Override
-    protected DataExecutionResponse run(DataBuilderContext dataBuilderContext,
-                                        DataFlowInstance dataFlowInstance,
-                                        DataDelta dataDelta,
-                                        DataFlow dataFlow,
-                                        DataBuilderFactory builderFactory) throws DataBuilderFrameworkException, DataValidationException {
-        CompletionService<DataContainer> completionExecutor = new ExecutorCompletionService<DataContainer>(executorService);
-        ExecutionGraph executionGraph = dataFlow.getExecutionGraph();
-        DataSet dataSet = dataFlowInstance.getDataSet().accessor().copy(); //Create own copy to work with
-        DataSetAccessor dataSetAccessor = DataSet.accessor(dataSet);
+    protected DataExecutionResponse run(
+            DataBuilderContext dataBuilderContext,
+            DataFlowInstance dataFlowInstance,
+            DataDelta dataDelta,
+            DataFlow dataFlow,
+            DataBuilderFactory builderFactory) throws DataBuilderFrameworkException, DataValidationException {
+        val completionExecutor = new ExecutorCompletionService<DataContainer>(executorService);
+        val executionGraph = dataFlow.getExecutionGraph();
+        val dataSet = dataFlowInstance.getDataSet().accessor().copy(); //Create own copy to work with
+        val dataSetAccessor = DataSet.accessor(dataSet);
         dataSetAccessor.merge(dataDelta);
-        Map<String, Data> responseData = Maps.newTreeMap();
-        Set<String> activeDataSet = Sets.newHashSet();
+        val responseData = Maps.<String, Data>newTreeMap();
+        val activeDataSet = Sets.<String>newHashSet();
 
-        for (Data data : dataDelta.getDelta()) {
-            activeDataSet.add(data.getData());
-        }
+        dataDelta.getDelta().stream().map(Data::getData).forEach(activeDataSet::add);
+
         List<List<DataBuilderMeta>> dependencyHierarchy = executionGraph.getDependencyHierarchy();
         Set<String> newlyGeneratedData = Sets.newHashSet();
         Set<DataBuilderMeta> processedBuilders = Collections.synchronizedSet(Sets.<DataBuilderMeta>newHashSet());
-        while(true) {
+        while (true) {
             for (List<DataBuilderMeta> levelBuilders : dependencyHierarchy) {
-                List<Future<DataContainer>> dataFutures = Lists.newArrayList();
+                val dataFutures = Lists.newArrayList();
                 BuilderRunner singleRef = null; //refrence to builderRunner when size of levelBuilders == 1 to avoid running it behind thread
                 for (DataBuilderMeta builderMeta : levelBuilders) {
                     if (processedBuilders.contains(builderMeta)) {
@@ -63,43 +64,48 @@ public class OptimizedMultiThreadedDataFlowExecutor extends DataFlowExecutor {
                     if (Sets.intersection(builderMeta.getEffectiveConsumes(), activeDataSet).isEmpty()) {
                         continue;
                     }
-                    DataBuilder builder = builderFactory.create(builderMeta);
+                    val builder = builderFactory.create(builderMeta);
                     if (!dataSetAccessor.checkForData(builder.getDataBuilderMeta().getConsumes())) {
                         continue;
                     }
-                    BuilderRunner builderRunner = new BuilderRunner(dataBuilderExecutionListener, dataFlowInstance,
-                                                                        builderMeta, dataDelta, responseData,
-                                                                        builder, dataBuilderContext, processedBuilders, dataSet);
-                   
-                    if(levelBuilders.size() == 1){
-                    	singleRef = builderRunner;
-                    }else{
-	                    Future<DataContainer> future = completionExecutor.submit(builderRunner);
-	                    dataFutures.add(future);
+                    val builderRunner = new BuilderRunner(dataBuilderExecutionListener, dataFlowInstance,
+                                                          dataDelta, responseData,
+                                                          builder,
+                                                          builderMeta,
+                                                          dataBuilderContext, processedBuilders, dataSet);
+
+                    if (levelBuilders.size() == 1) {
+                        singleRef = builderRunner;
+                    }
+                    else {
+                        dataFutures.add(completionExecutor.submit(builderRunner));
                     }
                 }
 
                 //Now wait for something to complete.
-                int listSize = dataFutures.size();
-                for(int i = 0; i < listSize || singleRef != null; i++) { //listSize == 0 when singleRef is present, or condition allows this logic to run once
+                val listSize = dataFutures.size();
+                for (int i = 0; i < listSize || singleRef != null; i++) { //listSize == 0 when singleRef is present, or condition allows this logic to run once
                     try {
                         DataContainer responseContainer = null;
-                        if(singleRef != null){
+                        if (singleRef != null) {
                             try {
                                 responseContainer = singleRef.call();
-                            } catch (Exception e) {
+                            }
+                            catch (Exception e) {
                                 throw new ExecutionException(e); //to map this to existing exception handling
-                            }finally{
+                            }
+                            finally {
                                 singleRef = null; // make this null to avoid loopback hell
                             }
-                        }else{
+                        }
+                        else {
                             responseContainer = completionExecutor.take().get();
                         }
 
-                        Data response = responseContainer.getGeneratedData();
-                        String data = responseContainer.getBuilderMeta().getProduces();
-                        if(responseContainer.isHasError()) {
-                            if(null != responseContainer.getValidationException()) {
+                        val response = responseContainer.getGeneratedData();
+                        val data = responseContainer.getBuilderMeta().getProduces();
+                        if (responseContainer.isHasError()) {
+                            if (null != responseContainer.getValidationException()) {
                                 throw responseContainer.getValidationException();
 
                             }
@@ -108,207 +114,52 @@ public class OptimizedMultiThreadedDataFlowExecutor extends DataFlowExecutor {
                         }
                         if (null != response) {
                             Preconditions.checkArgument(response.getData().equalsIgnoreCase(data),
-                                    String.format("Builder is supposed to produce %s but produces %s",
-                                            data, response.getData()));
+                                                        String.format(
+                                                                "Builder is supposed to produce %s but produces %s",
+                                                                data,
+                                                                response.getData()));
                             dataSetAccessor.merge(response);
                             responseData.put(response.getData(), response);
                             activeDataSet.add(response.getData());
-                            if(null != dataFlow.getTransients() && !dataFlow.getTransients().contains(response.getData())) {
+                            if (null != dataFlow.getTransients() && !dataFlow.getTransients()
+                                    .contains(response.getData())) {
                                 newlyGeneratedData.add(response.getData());
                             }
                         }
                     }
                     catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
                         throw new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.BUILDER_EXECUTION_ERROR,
-                                "Error while waiting for error ", e);
-                    } catch (ExecutionException e) {
+                                                                "Error while waiting for error ", e);
+                    }
+                    catch (ExecutionException e) {
                         throw new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.BUILDER_EXECUTION_ERROR,
-                                "Error while waiting for error ", e.getCause());
+                                                                "Error while waiting for error ", e.getCause());
                     }
                 }
             }
-            if(newlyGeneratedData.contains(dataFlow.getTargetData())) {
-                //logger.debug("Finished running this instance of the flow. Exiting.");
+            if (newlyGeneratedData.contains(dataFlow.getTargetData())) {
+                log.trace("Finished running this instance of the flow. Exiting.");
                 break;
             }
-            if(newlyGeneratedData.isEmpty()) {
-                //logger.debug("Nothing happened in this loop, exiting..");
+            if (newlyGeneratedData.isEmpty()) {
+                log.trace("Nothing happened in this loop, exiting..");
                 break;
             }
 //            StringBuilder stringBuilder = new StringBuilder();
 //            for(String data : newlyGeneratedData) {
 //                stringBuilder.append(data + ", ");
 //            }
-            //logger.info("Newly generated: " + stringBuilder);
+            log.trace("Newly generated: {}", newlyGeneratedData);
             activeDataSet.clear();
             activeDataSet.addAll(newlyGeneratedData);
             newlyGeneratedData.clear();
-            if(!dataFlow.isLoopingEnabled()) {
+            if (!dataFlow.isLoopingEnabled()) {
                 break;
             }
         }
-        DataSet finalDataSet = dataSetAccessor.copy(dataFlow.getTransients());
-        dataFlowInstance.setDataSet(finalDataSet);
+        dataFlowInstance.setDataSet(dataSetAccessor.copy(dataFlow.getTransients()));
         return new DataExecutionResponse(responseData);
-    }
-
-    private static final class DataContainer {
-        private final DataBuilderMeta builderMeta;
-        private final Data generatedData;
-        private boolean hasError = false;
-        private final DataBuilderFrameworkException exception;
-        private final DataValidationException validationException;
-
-        private DataContainer(DataBuilderMeta builderMeta, Data generatedData) {
-            this.builderMeta = builderMeta;
-            this.generatedData = generatedData;
-            this.exception = null;
-            this.validationException = null;
-        }
-
-        private DataContainer(DataBuilderMeta builderMeta, DataBuilderFrameworkException exception) {
-            this.builderMeta = builderMeta;
-            this.generatedData = null;
-            this.hasError = true;
-            this.exception = exception;
-            this.validationException = null;
-        }
-
-        private DataContainer(DataBuilderMeta builderMeta, DataValidationException validationException) {
-            this.builderMeta = builderMeta;
-            this.generatedData = null;
-            this.hasError = true;
-            this.exception = null;
-            this.validationException = validationException;
-        }
-
-
-
-        public DataBuilderMeta getBuilderMeta() {
-            return builderMeta;
-        }
-
-        public Data getGeneratedData() {
-            return generatedData;
-        }
-
-        public DataBuilderFrameworkException getException() {
-            return exception;
-        }
-
-        public DataValidationException getValidationException() {
-            return validationException;
-        }
-
-        public boolean isHasError() {
-            return hasError;
-        }
-    }
-    private static final class BuilderRunner implements Callable<DataContainer> {
-
-        private List<DataBuilderExecutionListener> dataBuilderExecutionListener;
-        private DataFlowInstance dataFlowInstance;
-        private DataBuilderMeta builderMeta;
-        private DataDelta dataDelta;
-        private Map<String,Data> responseData;
-        private DataBuilder builder;
-        private DataBuilderContext dataBuilderContext;
-        private final Set<DataBuilderMeta> procesedBuilders;
-        private DataSet dataSet;
-
-        private BuilderRunner(List<DataBuilderExecutionListener> dataBuilderExecutionListener,
-                              DataFlowInstance dataFlowInstance,
-                              DataBuilderMeta builderMeta,
-                              DataDelta dataDelta,
-                              Map<String, Data> responseData,
-                              DataBuilder builder,
-                              DataBuilderContext dataBuilderContext,
-                              Set<DataBuilderMeta> procesedBuilders,
-                              DataSet dataSet) {
-            this.dataBuilderExecutionListener = dataBuilderExecutionListener;
-            this.dataFlowInstance = dataFlowInstance;
-            this.builderMeta = builderMeta;
-            this.dataDelta = dataDelta;
-            this.responseData = responseData;
-            this.builder = builder;
-            this.dataBuilderContext = dataBuilderContext;
-            this.procesedBuilders = procesedBuilders;
-            this.dataSet = dataSet;
-        }
-
-        @Override
-        public DataContainer call() throws Exception {
-
-            for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
-                try {
-                    listener.beforeExecute(dataBuilderContext, dataFlowInstance, builderMeta, dataDelta, responseData);
-                } catch (Throwable t) {
-                    logger.error("Error running pre-execution execution listener: ", t);
-                }
-            }
-            try {
-                Data response = builder.process(dataBuilderContext.immutableCopy(
-                                            dataSet.accessor().getAccesibleDataSetFor(builder)));
-                //logger.debug("Ran " + builderMeta.getName());
-                procesedBuilders.add(builderMeta);
-                for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
-                    try {
-                        listener.afterExecute(dataBuilderContext, dataFlowInstance, builderMeta, dataDelta, responseData, response);
-                    } catch (Throwable t) {
-                        logger.error("Error running post-execution listener: ", t);
-                    }
-                }
-                if(null != response) {
-                    Preconditions.checkArgument(response.getData().equalsIgnoreCase(builderMeta.getProduces()),
-                            String.format("Builder is supposed to produce %s but produces %s",
-                                    builderMeta.getProduces(), response.getData()));
-                    response.setGeneratedBy(builderMeta.getName());
-                }
-                return new DataContainer(builderMeta, response);
-            } catch (DataBuilderException e) {
-                logger.error("Error running builder: " + builderMeta.getName());
-                for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
-                    try {
-                        listener.afterException(dataBuilderContext, dataFlowInstance, builderMeta, dataDelta, responseData, e);
-
-                    } catch (Throwable error) {
-                        logger.error("Error running post-execution listener: ", error);
-                    }
-                }
-                return new DataContainer(builderMeta, new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.BUILDER_EXECUTION_ERROR,
-                        "Error running builder: " + builderMeta.getName(), e.getDetails(), e));
-
-            } catch (DataValidationException e) {
-                logger.error("Validation error in data produced by builder" +builderMeta.getName());
-                for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
-                    try {
-                        listener.afterException(dataBuilderContext, dataFlowInstance, builderMeta, dataDelta, responseData, e);
-
-                    } catch (Throwable error) {
-                        logger.error("Error running post-execution listener: ", error);
-                    }
-                }
-                return new DataContainer(builderMeta, new DataValidationException(DataValidationException.ErrorCode.DATA_VALIDATION_EXCEPTION,
-                        "Error running builder: " + builderMeta.getName(), new DataExecutionResponse(responseData), e.getDetails(), e));
-
-
-            }
-            catch (Throwable t) {
-                logger.error("Error running builder: " + builderMeta.getName());
-                for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
-                    try {
-                        listener.afterException(dataBuilderContext, dataFlowInstance, builderMeta, dataDelta, responseData, t);
-
-                    } catch (Throwable error) {
-                        logger.error("Error running post-execution listener: ", error);
-                    }
-                }
-                Map<String, Object> objectMap = new HashMap<String, Object>();
-                objectMap.put("MESSAGE", t.getMessage());
-                return new DataContainer(builderMeta, new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.BUILDER_EXECUTION_ERROR,
-                        "Error running builder: " + builderMeta.getName() + t.getMessage(), objectMap, t));
-            }
-        }
     }
 
 }

--- a/src/main/java/io/appform/databuilderframework/engine/ProxyDataBuilder.java
+++ b/src/main/java/io/appform/databuilderframework/engine/ProxyDataBuilder.java
@@ -2,14 +2,18 @@ package io.appform.databuilderframework.engine;
 
 import io.appform.databuilderframework.model.Data;
 import io.appform.databuilderframework.model.DataBuilderMeta;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = true)
 public class ProxyDataBuilder extends DataBuilder {
     private final DataBuilder impl;
 
     ProxyDataBuilder(DataBuilderMeta dataBuilderMeta, DataBuilder impl) {
         this.impl = impl;
         setDataBuilderMeta(dataBuilderMeta);
+        impl.setDataBuilderMeta(dataBuilderMeta);
     }
+
     @Override
     public Data process(DataBuilderContext context) throws DataBuilderException, DataValidationException {
         return impl.process(context);

--- a/src/main/java/io/appform/databuilderframework/engine/SimpleDataFlowExecutor.java
+++ b/src/main/java/io/appform/databuilderframework/engine/SimpleDataFlowExecutor.java
@@ -1,26 +1,25 @@
 package io.appform.databuilderframework.engine;
 
-import io.appform.databuilderframework.model.*;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.appform.databuilderframework.model.*;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.TreeMap;
 
 /**
  * The executor for a {@link io.appform.databuilderframework.model.DataFlow}.
  */
+@Slf4j
+@SuppressWarnings("java:S1181")
 public class SimpleDataFlowExecutor extends DataFlowExecutor {
-    private static final Logger logger = LoggerFactory.getLogger(SimpleDataFlowExecutor.class.getSimpleName());
 
     public SimpleDataFlowExecutor() {
-
+        this(null);
     }
 
     public SimpleDataFlowExecutor(DataBuilderFactory dataBuilderFactory) {
@@ -30,28 +29,28 @@ public class SimpleDataFlowExecutor extends DataFlowExecutor {
     /*
      * {@inheritDoc}
      */
-    protected DataExecutionResponse run(DataBuilderContext dataBuilderContext,
-                                        DataFlowInstance dataFlowInstance,
-                                        DataDelta dataDelta,
-                                        DataFlow dataFlow,
-                                        DataBuilderFactory builderFactory) throws DataBuilderFrameworkException, DataValidationException {
-        ExecutionGraph executionGraph = dataFlow.getExecutionGraph();
-        DataSet dataSet = dataFlowInstance.getDataSet().accessor().copy(); //Create own copy to work with
-        DataSetAccessor dataSetAccessor = DataSet.accessor(dataSet);
-        dataSetAccessor.merge(dataDelta);
-        Map<String, Data> responseData = Maps.newTreeMap();
-        Set<String> activeDataSet = Sets.newHashSet();
+    protected DataExecutionResponse run(
+            DataBuilderContext dataBuilderContext,
+            DataFlowInstance dataFlowInstance,
+            DataDelta dataDelta,
+            DataFlow dataFlow,
+            DataBuilderFactory builderFactory) throws DataBuilderFrameworkException, DataValidationException {
+        val executionGraph = dataFlow.getExecutionGraph();
+        val dataSet = dataFlowInstance.getDataSet().accessor().copy(); //Create own copy to work with
+        val dataSetAccessor = DataSet.accessor(dataSet);
+        val responseData = new TreeMap<String, Data>();
+        val activeDataSet = new HashSet<String>();
+        val dependencyHierarchy = executionGraph.getDependencyHierarchy();
+        val newlyGeneratedData = new HashSet<String>();
+        val processedBuilders = Collections.synchronizedSet(new HashSet<DataBuilderMeta>());
 
-        activeDataSet.addAll(dataDelta.getDelta()
-                .stream()
-                .map(Data::getData)
-                .collect(Collectors.toList()));
-        List<List<DataBuilderMeta>> dependencyHierarchy = executionGraph.getDependencyHierarchy();
-        Set<String> newlyGeneratedData = Sets.newHashSet();
-        Set<DataBuilderMeta> processedBuilders = Sets.newHashSet();
-        while(true) {
-            for (List<DataBuilderMeta> levelBuilders : dependencyHierarchy) {
-                for (DataBuilderMeta builderMeta : levelBuilders) {
+        dataSetAccessor.merge(dataDelta);
+        dataDelta.getDelta().forEach(data -> activeDataSet.add(data.getData()));
+
+        boolean completed = false;
+        while (!completed) {
+            for (val levelBuilders : dependencyHierarchy) {
+                for (val builderMeta : levelBuilders) {
                     if (processedBuilders.contains(builderMeta)) {
                         continue;
                     }
@@ -65,107 +64,137 @@ public class SimpleDataFlowExecutor extends DataFlowExecutor {
                     }
                     for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
                         try {
-                            listener.beforeExecute(dataBuilderContext, dataFlowInstance, builderMeta, dataDelta, responseData);
-                        } catch (Throwable t) {
-                            logger.error("Error running pre-execution execution listener: ", t);
+                            listener.beforeExecute(dataBuilderContext,
+                                                   dataFlowInstance,
+                                                   builderMeta,
+                                                   dataDelta,
+                                                   responseData);
+                        }
+                        catch (Throwable t) {
+                            log.error("Error running pre-execution execution listener: ", t);
                         }
                     }
                     try {
                         Data response = builder.process(
-                                                    dataBuilderContext.immutableCopy(
-                                                            dataSet.accessor().getAccesibleDataSetFor(builder)));
+                                dataBuilderContext.immutableCopy(
+                                        dataSet.accessor().getAccesibleDataSetFor(builder)));
                         if (null != response) {
                             Preconditions.checkArgument(response.getData().equalsIgnoreCase(builderMeta.getProduces()),
-                                                String.format("Builder is supposed to produce %s but produces %s",
-                                                                builderMeta.getProduces(), response.getData()));
+                                                        String.format(
+                                                                "Builder is supposed to produce %s but produces %s",
+                                                                builderMeta.getProduces(),
+                                                                response.getData()));
                             dataSetAccessor.merge(response);
                             responseData.put(response.getData(), response);
                             response.setGeneratedBy(builderMeta.getName());
                             activeDataSet.add(response.getData());
-                            if(null != dataFlow.getTransients() && !dataFlow.getTransients().contains(response.getData())) {
+                            if (null != dataFlow.getTransients() && !dataFlow.getTransients()
+                                    .contains(response.getData())) {
                                 newlyGeneratedData.add(response.getData());
                             }
                         }
-                        //logger.debug("Ran " + builderMeta.getName());
+                        log.trace("Ran " + builderMeta.getName());
                         processedBuilders.add(builderMeta);
                         for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
                             try {
-                                listener.afterExecute(dataBuilderContext, dataFlowInstance, builderMeta, dataDelta, responseData, response);
-                            } catch (Throwable t) {
-                                logger.error("Error running post-execution listener: ", t);
+                                listener.afterExecute(dataBuilderContext,
+                                                      dataFlowInstance,
+                                                      builderMeta,
+                                                      dataDelta,
+                                                      responseData,
+                                                      response);
+                            }
+                            catch (Throwable t) {
+                                log.error("Error running post-execution listener: ", t);
                             }
                         }
 
-                    } catch (DataBuilderException e) {
-                        logger.error("Error running builder: " + builderMeta.getName());
-                        for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
-                            try {
-                                listener.afterException(dataBuilderContext, dataFlowInstance, builderMeta, dataDelta, responseData, e);
+                    }
+                    catch (DataBuilderException e) {
+                        executePostExceptionListeners(dataBuilderContext,
+                                                      dataFlowInstance,
+                                                      dataDelta,
+                                                      responseData,
+                                                      builderMeta,
+                                                      e);
 
-                            } catch (Throwable error) {
-                                logger.error("Error running post-execution listener: ", error);
-                            }
-                        }
                         throw new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.BUILDER_EXECUTION_ERROR,
-                                "Error running builder: " + builderMeta.getName(), e.getDetails(), e, new DataExecutionResponse(responseData));
+                                                                "Error running builder: " + builderMeta.getName(),
+                                                                e.getDetails(),
+                                                                e,
+                                                                new DataExecutionResponse(responseData));
 
-                    } catch (DataValidationException e) {
-                        logger.error("Validation error in data produced by builder" +builderMeta.getName());
-                        for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
-                            try {
-                                listener.afterException(dataBuilderContext, dataFlowInstance, builderMeta, dataDelta, responseData, e);
-
-                            } catch (Throwable error) {
-                                logger.error("Error running post-execution listener: ", error);
-                            }
-                        }
+                    }
+                    catch (DataValidationException e) {
+                        executePostExceptionListeners(dataBuilderContext,
+                                                      dataFlowInstance,
+                                                      dataDelta,
+                                                      responseData,
+                                                      builderMeta,
+                                                      e);
                         // Sending Execution response in exception object
 
-                        throw new DataValidationException(DataValidationException.ErrorCode.DATA_VALIDATION_EXCEPTION, e.getMessage(), new DataExecutionResponse(responseData),e.getDetails(), e);
+                        throw new DataValidationException(DataValidationException.ErrorCode.DATA_VALIDATION_EXCEPTION,
+                                                          e.getMessage(),
+                                                          new DataExecutionResponse(responseData),
+                                                          e.getDetails(),
+                                                          e);
 
 
                     }
                     catch (Throwable t) {
-                        logger.error("Error running builder: " + builderMeta.getName());
-                        for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
-                            try {
-                                listener.afterException(dataBuilderContext, dataFlowInstance, builderMeta, dataDelta, responseData, t);
-
-                            } catch (Throwable error) {
-                                logger.error("Error running post-execution listener: ", error);
-                            }
-                        }
-                        Map<String, Object> objectMap = new HashMap<String, Object>();
-                        objectMap.put("MESSAGE", t.getMessage());
+                        executePostExceptionListeners(dataBuilderContext,
+                                                      dataFlowInstance,
+                                                      dataDelta,
+                                                      responseData,
+                                                      builderMeta,
+                                                      t);
                         throw new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.BUILDER_EXECUTION_ERROR,
-                                "Error running builder: " + builderMeta.getName()
-                                        + ": " + t.getMessage(), objectMap, t, new DataExecutionResponse(responseData));
+                                                                "Error running builder: " + builderMeta.getName()
+                                                                        + ": " + t.getMessage(),
+                                                                Collections.singletonMap("MESSAGE", t.getMessage()),
+                                                                t,
+                                                                new DataExecutionResponse(responseData));
                     }
                 }
             }
-            if(newlyGeneratedData.contains(dataFlow.getTargetData())) {
-                //logger.debug("Finished running this instance of the flow. Exiting.");
-                break;
+            completed = newlyGeneratedData.contains(dataFlow.getTargetData())
+                    || newlyGeneratedData.isEmpty();
+            if (newlyGeneratedData.contains(dataFlow.getTargetData())) {
+                log.trace("Finished running this instance of the flow. Exiting.");
             }
-            if(newlyGeneratedData.isEmpty()) {
-                //logger.debug("Nothing happened in this loop, exiting..");
-                break;
+            if (newlyGeneratedData.isEmpty()) {
+                log.trace("Nothing happened in this loop, exiting..");
             }
-//            StringBuilder stringBuilder = new StringBuilder();
-//            for(String data : newlyGeneratedData) {
-//                stringBuilder.append(data + ", ");
-//            }
-            //logger.info("Newly generated: " + stringBuilder);
+            //Some data generated which is not the target. But we're done here
+            log.trace("Newly generated: {}", newlyGeneratedData);
             activeDataSet.clear();
             activeDataSet.addAll(newlyGeneratedData);
             newlyGeneratedData.clear();
-            if(!dataFlow.isLoopingEnabled()) {
-                break;
-            }
+            completed = completed || !dataFlow.isLoopingEnabled();
         }
         DataSet finalDataSet = dataSetAccessor.copy(dataFlow.getTransients());
         dataFlowInstance.setDataSet(finalDataSet);
         return new DataExecutionResponse(responseData);
+    }
+
+    private void executePostExceptionListeners(
+            DataBuilderContext dataBuilderContext,
+            DataFlowInstance dataFlowInstance,
+            DataDelta dataDelta,
+            Map<String, Data> responseData,
+            DataBuilderMeta builderMeta,
+            Throwable e) {
+        log.error("Error running builder: {}", builderMeta.getName());
+        for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
+            try {
+                listener.afterException(dataBuilderContext, dataFlowInstance, builderMeta, dataDelta, responseData, e);
+
+            }
+            catch (Throwable error) {
+                log.error("Error running post-execution listener: ", error);
+            }
+        }
     }
 
 }

--- a/src/main/java/io/appform/databuilderframework/engine/Utils.java
+++ b/src/main/java/io/appform/databuilderframework/engine/Utils.java
@@ -1,15 +1,13 @@
 package io.appform.databuilderframework.engine;
 
-import io.appform.databuilderframework.annotations.DataBuilderClassInfo;
-import io.appform.databuilderframework.annotations.DataBuilderInfo;
-import io.appform.databuilderframework.model.Data;
-import io.appform.databuilderframework.model.DataBuilderMeta;
 import com.google.common.base.CaseFormat;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import io.appform.databuilderframework.model.DataDelta;
-import io.appform.databuilderframework.model.DataFlowInstance;
+import io.appform.databuilderframework.annotations.DataBuilderClassInfo;
+import io.appform.databuilderframework.annotations.DataBuilderInfo;
+import io.appform.databuilderframework.model.Data;
+import io.appform.databuilderframework.model.DataBuilderMeta;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,11 +28,11 @@ public final class Utils {
         return CaseFormat.UPPER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, clazz.getSimpleName());
     }
 
-    public static boolean isEmpty(Collection collection) {
+    public static<T> boolean isEmpty(Collection<T> collection) {
         return null == collection || collection.isEmpty();
     }
 
-    public static boolean isEmpty(Map collection) {
+    public static<K,V> boolean isEmpty(Map<K,V> collection) {
         return null == collection || collection.isEmpty();
     }
 
@@ -102,25 +100,6 @@ public final class Utils {
                     ImmutableSet.copyOf(optionals),
                     ImmutableSet.copyOf(access)
             );
-        }
-    }
-
-    public static void executePostExeceptionListener(
-            DataBuilderContext dataBuilderContext,
-            DataFlowInstance dataFlowInstance,
-            DataDelta dataDelta,
-            Map<String, Data> responseData,
-            DataBuilderMeta builderMeta,
-            DataValidationException e,
-            List<DataBuilderExecutionListener> dataBuilderExecutionListener) {
-        log.error("Validation error in data produced by builder" + builderMeta.getName());
-        for (DataBuilderExecutionListener listener : dataBuilderExecutionListener) {
-            try {
-                listener.afterException(dataBuilderContext, dataFlowInstance, builderMeta, dataDelta, responseData, e);
-
-            } catch (Throwable error) {
-                log.error("Error running post-execution listener: ", error);
-            }
         }
     }
 }

--- a/src/main/java/io/appform/databuilderframework/engine/impl/InstantiatingDataBuilderFactory.java
+++ b/src/main/java/io/appform/databuilderframework/engine/impl/InstantiatingDataBuilderFactory.java
@@ -5,44 +5,43 @@ import io.appform.databuilderframework.engine.DataBuilderFactory;
 import io.appform.databuilderframework.engine.DataBuilderFrameworkException;
 import io.appform.databuilderframework.engine.DataBuilderMetadataManager;
 import io.appform.databuilderframework.model.DataBuilderMeta;
+import lombok.val;
 
 /**
- * @inheritDoc
- * This particular version, uses metadata stored in {@link io.appform.databuilderframework.engine.DataBuilderMetadataManager}
+ * @inheritDoc This particular version, uses metadata stored in {@link io.appform.databuilderframework.engine.DataBuilderMetadataManager}
  * to generate a specific builder.
  */
 public class InstantiatingDataBuilderFactory implements DataBuilderFactory {
-    private DataBuilderMetadataManager dataBuilderMetadataManager;
-    private boolean useCurrentMeta;
+    private final DataBuilderMetadataManager dataBuilderMetadataManager;
+    private final boolean useCurrentMeta;
 
     public InstantiatingDataBuilderFactory(DataBuilderMetadataManager dataBuilderMetadataManager) {
         this(dataBuilderMetadataManager, false);
     }
 
-    public InstantiatingDataBuilderFactory(DataBuilderMetadataManager dataBuilderMetadataManager, boolean useCurrentMeta) {
+    public InstantiatingDataBuilderFactory(
+            DataBuilderMetadataManager dataBuilderMetadataManager,
+            boolean useCurrentMeta) {
         this.dataBuilderMetadataManager = dataBuilderMetadataManager;
         this.useCurrentMeta = useCurrentMeta;
     }
 
     public DataBuilder create(DataBuilderMeta dataBuilderMeta) throws DataBuilderFrameworkException {
-        final String builderName = dataBuilderMeta.getName();
-        Class<? extends DataBuilder> dataBuilderClass = dataBuilderMetadataManager.getDataBuilderClass(builderName);
-        if(null == dataBuilderClass) {
+        val builderName = dataBuilderMeta.getName();
+        val dataBuilderClass = dataBuilderMetadataManager.getDataBuilderClass(builderName);
+        if (null == dataBuilderClass) {
             throw new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.NO_BUILDER_FOUND_FOR_NAME,
-                                    "No builder found for name: " + builderName);
+                                                    "No builder found for name: " + builderName);
         }
         try {
-            DataBuilder dataBuilder = dataBuilderClass.newInstance();
-            if(useCurrentMeta) {
-                dataBuilder.setDataBuilderMeta(dataBuilderMetadataManager.get(builderName).deepCopy());
-            }
-            else {
-                dataBuilder.setDataBuilderMeta(dataBuilderMeta.deepCopy());
-            }
-            return dataBuilder;
-        } catch (Exception e) {
+            val dataBuilder = dataBuilderClass.newInstance();
+            return useCurrentMeta
+                    ? dataBuilder.setDataBuilderMeta(dataBuilderMetadataManager.get(builderName).deepCopy())
+                   : dataBuilder.setDataBuilderMeta(dataBuilderMeta.deepCopy());
+        }
+        catch (Exception e) {
             throw new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.INSTANTIATION_FAILURE,
-                                    "Could not instantiate builder: " + builderName);
+                                                    "Could not instantiate builder: " + builderName);
         }
     }
 

--- a/src/main/java/io/appform/databuilderframework/engine/impl/InstantiatingDataBuilderFactory.java
+++ b/src/main/java/io/appform/databuilderframework/engine/impl/InstantiatingDataBuilderFactory.java
@@ -8,7 +8,7 @@ import io.appform.databuilderframework.model.DataBuilderMeta;
 import lombok.val;
 
 /**
- * @inheritDoc This particular version, uses metadata stored in {@link io.appform.databuilderframework.engine.DataBuilderMetadataManager}
+ * {@inheritDoc} This particular version, uses metadata stored in {@link io.appform.databuilderframework.engine.DataBuilderMetadataManager}
  * to generate a specific builder.
  */
 public class InstantiatingDataBuilderFactory implements DataBuilderFactory {

--- a/src/main/java/io/appform/databuilderframework/engine/impl/MixedDataBuilderFactory.java
+++ b/src/main/java/io/appform/databuilderframework/engine/impl/MixedDataBuilderFactory.java
@@ -1,18 +1,18 @@
 package io.appform.databuilderframework.engine.impl;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderFactory;
 import io.appform.databuilderframework.engine.DataBuilderFrameworkException;
 import io.appform.databuilderframework.engine.DataBuilderMetadataManager;
 import io.appform.databuilderframework.model.DataBuilderMeta;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
+import lombok.val;
 
 import java.util.Map;
 
 /**
- * @inheritDoc
- * This particular version, uses metadata stored in {@link io.appform.databuilderframework.engine.DataBuilderMetadataManager}
+ * @inheritDoc This particular version, uses metadata stored in {@link io.appform.databuilderframework.engine.DataBuilderMetadataManager}
  * to generate a specific builder.
  */
 public class MixedDataBuilderFactory implements DataBuilderFactory {
@@ -41,33 +41,30 @@ public class MixedDataBuilderFactory implements DataBuilderFactory {
     }
 
     public DataBuilder create(DataBuilderMeta dataBuilderMeta) throws DataBuilderFrameworkException {
-        final String builderName = dataBuilderMeta.getName();
-        if(builderInstances.containsKey(builderName)) {
+        val builderName = dataBuilderMeta.getName();
+        if (builderInstances.containsKey(builderName)) {
             return builderInstances.get(builderName);
         }
-        Class<? extends DataBuilder> dataBuilderClass = dataBuilderMetadataManager.getDataBuilderClass(builderName);
-        if(null == dataBuilderClass) {
+        val dataBuilderClass = dataBuilderMetadataManager.getDataBuilderClass(builderName);
+        if (null == dataBuilderClass) {
             throw new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.NO_BUILDER_FOUND_FOR_NAME,
-                                    "No builder found for name: " + builderName);
+                                                    "No builder found for name: " + builderName);
         }
         try {
-            DataBuilder dataBuilder = dataBuilderClass.newInstance();
-            if(useCurrentMeta) {
-                dataBuilder.setDataBuilderMeta(dataBuilderMetadataManager.get(builderName).deepCopy());
-            }
-            else {
-                dataBuilder.setDataBuilderMeta(dataBuilderMeta.deepCopy());
-            }
-            return dataBuilder;
-        } catch (Exception e) {
+            val dataBuilder = dataBuilderClass.newInstance();
+            return useCurrentMeta
+                    ? dataBuilder.setDataBuilderMeta(dataBuilderMetadataManager.get(builderName).deepCopy())
+                   : dataBuilder.setDataBuilderMeta(dataBuilderMeta.deepCopy());
+        }
+        catch (Exception e) {
             throw new DataBuilderFrameworkException(DataBuilderFrameworkException.ErrorCode.INSTANTIATION_FAILURE,
-                                    "Could not instantiate builder: " + builderName);
+                                                    "Could not instantiate builder: " + builderName);
         }
     }
 
     public MixedDataBuilderFactory immutableCopy() {
         return new MixedDataBuilderFactory(ImmutableMap.copyOf(builderInstances),
-                                            dataBuilderMetadataManager.immutableCopy(),
-                                            useCurrentMeta);
+                                           dataBuilderMetadataManager.immutableCopy(),
+                                           useCurrentMeta);
     }
 }

--- a/src/main/java/io/appform/databuilderframework/engine/impl/MixedDataBuilderFactory.java
+++ b/src/main/java/io/appform/databuilderframework/engine/impl/MixedDataBuilderFactory.java
@@ -12,7 +12,7 @@ import lombok.val;
 import java.util.Map;
 
 /**
- * @inheritDoc This particular version, uses metadata stored in {@link io.appform.databuilderframework.engine.DataBuilderMetadataManager}
+ * {@inheritDoc} This particular version, uses metadata stored in {@link io.appform.databuilderframework.engine.DataBuilderMetadataManager}
  * to generate a specific builder.
  */
 public class MixedDataBuilderFactory implements DataBuilderFactory {

--- a/src/main/java/io/appform/databuilderframework/model/DataFlowInstance.java
+++ b/src/main/java/io/appform/databuilderframework/model/DataFlowInstance.java
@@ -1,6 +1,7 @@
 package io.appform.databuilderframework.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.constraints.NotNull;
@@ -10,6 +11,7 @@ import javax.validation.constraints.NotNull;
  * This class represents a running instance of the flow. It contains the flow itself as well as the
  * {@link io.appform.databuilderframework.model.DataSet} required for execution.
  */
+@Data
 public class DataFlowInstance {
 
     /**
@@ -44,29 +46,5 @@ public class DataFlowInstance {
 
     public DataFlowInstance(String id, DataFlow dataFlow) {
         this(id, dataFlow, new DataSet());
-    }
-
-    public DataFlow getDataFlow() {
-        return dataFlow;
-    }
-
-    public void setDataFlow(DataFlow dataFlow) {
-        this.dataFlow = dataFlow;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public DataSet getDataSet() {
-        return dataSet;
-    }
-
-    public void setDataSet(DataSet dataSet) {
-        this.dataSet = dataSet;
     }
 }

--- a/src/test/java/examples/bloghomepagebuilder/builders/ApiAuthChecker.java
+++ b/src/test/java/examples/bloghomepagebuilder/builders/ApiAuthChecker.java
@@ -7,12 +7,13 @@ import io.appform.databuilderframework.engine.DataBuilderException;
 import io.appform.databuilderframework.model.Data;
 import examples.bloghomepagebuilder.data.ApiAuthValid;
 import examples.bloghomepagebuilder.data.HomePageRequest;
+import lombok.val;
 
 @DataBuilderClassInfo(produces = ApiAuthValid.class, consumes = HomePageRequest.class)
 public class ApiAuthChecker extends DataBuilder {
     @Override
     public Data process(DataBuilderContext context) throws DataBuilderException {
-        HomePageRequest request = context.getDataSet().accessor().get(HomePageRequest.class);
+        val request = context.getDataSet().accessor().get(HomePageRequest.class);
         //Do actual validation....
         return new ApiAuthValid(true, request.getUserAuthToken());
     }

--- a/src/test/java/examples/bloghomepagebuilder/builders/BlogPostSource.java
+++ b/src/test/java/examples/bloghomepagebuilder/builders/BlogPostSource.java
@@ -1,23 +1,23 @@
 package examples.bloghomepagebuilder.builders;
 
 
+import examples.bloghomepagebuilder.data.BlogId;
+import examples.bloghomepagebuilder.data.BlogPost;
+import examples.bloghomepagebuilder.data.UserDetails;
 import io.appform.databuilderframework.annotations.DataBuilderClassInfo;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.model.Data;
-import examples.bloghomepagebuilder.data.BlogId;
-import examples.bloghomepagebuilder.data.BlogPost;
-import examples.bloghomepagebuilder.data.UserDetails;
+import lombok.val;
 
 @DataBuilderClassInfo(produces = BlogPost.class, consumes = {UserDetails.class, BlogId.class})
 public class BlogPostSource extends DataBuilder {
     @Override
     public Data process(DataBuilderContext context) throws DataBuilderException {
-        final DataSetAccessor accessor = context.getDataSet().accessor();
-        UserDetails userDetails = accessor.get(UserDetails.class);
-        BlogId blogId = accessor.get(BlogId.class);
+        val accessor = context.getDataSet().accessor();
+        val userDetails = accessor.get(UserDetails.class);
+        val blogId = accessor.get(BlogId.class);
         //Get blog for this user and id
         return new BlogPost("A data depndent frame work",
                 "Blah .. blah and some more blah".getBytes());

--- a/src/test/java/examples/bloghomepagebuilder/builders/GetFollowers.java
+++ b/src/test/java/examples/bloghomepagebuilder/builders/GetFollowers.java
@@ -9,12 +9,13 @@ import com.google.common.collect.ImmutableList;
 import examples.bloghomepagebuilder.data.ApiAuthValid;
 import examples.bloghomepagebuilder.data.FollowerList;
 import examples.bloghomepagebuilder.data.UserDetails;
+import lombok.val;
 
 @DataBuilderClassInfo(produces = FollowerList.class, consumes = {ApiAuthValid.class, UserDetails.class})
 public class GetFollowers extends DataBuilder {
     @Override
     public Data process(DataBuilderContext context) throws DataBuilderException {
-        UserDetails userDetails = context.getDataSet().accessor().get(UserDetails.class);
+        val userDetails = context.getDataSet().accessor().get(UserDetails.class);
         //Do something and get follower list
         return new FollowerList(ImmutableList.of("Gaurav Prasad", "Ajay Singh", "Gokulvanan Velan"));
     }

--- a/src/test/java/examples/bloghomepagebuilder/builders/HomePageBuilder.java
+++ b/src/test/java/examples/bloghomepagebuilder/builders/HomePageBuilder.java
@@ -1,12 +1,12 @@
 package examples.bloghomepagebuilder.builders;
 
+import examples.bloghomepagebuilder.data.*;
 import io.appform.databuilderframework.annotations.DataBuilderClassInfo;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.model.Data;
-import examples.bloghomepagebuilder.data.*;
+import lombok.val;
 
 @DataBuilderClassInfo(produces = HomePageResponse.class, consumes = {UserDetails.class, BlogPost.class, PostList.class, FollowerList.class, RecommendedTags.class})
 public class HomePageBuilder extends DataBuilder {
@@ -17,7 +17,7 @@ public class HomePageBuilder extends DataBuilder {
 
     @Override
     public Data process(DataBuilderContext context) throws DataBuilderException {
-        final DataSetAccessor dataSetAccessor = context.getDataSet().accessor();
+        val dataSetAccessor = context.getDataSet().accessor();
         return new HomePageResponse(
                         dataSetAccessor.get(UserDetails.class).getUserName(),
                         dataSetAccessor.get(BlogPost.class).getTitle(),

--- a/src/test/java/examples/bloghomepagebuilder/builders/LatestBlogSelector.java
+++ b/src/test/java/examples/bloghomepagebuilder/builders/LatestBlogSelector.java
@@ -1,18 +1,19 @@
 package examples.bloghomepagebuilder.builders;
 
+import examples.bloghomepagebuilder.data.BlogId;
+import examples.bloghomepagebuilder.data.PostList;
 import io.appform.databuilderframework.annotations.DataBuilderClassInfo;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
 import io.appform.databuilderframework.model.Data;
-import examples.bloghomepagebuilder.data.BlogId;
-import examples.bloghomepagebuilder.data.PostList;
+import lombok.val;
 
 @DataBuilderClassInfo(produces = BlogId.class, consumes = PostList.class)
 public class LatestBlogSelector extends DataBuilder{
     @Override
     public Data process(DataBuilderContext context) throws DataBuilderException {
-        PostList postList = context.getDataSet().accessor().get(PostList.class);
+        val postList = context.getDataSet().accessor().get(PostList.class);
         //Select the appropriate blog
         return new BlogId("blog-123");
     }

--- a/src/test/java/examples/bloghomepagebuilder/builders/UserDataExpander.java
+++ b/src/test/java/examples/bloghomepagebuilder/builders/UserDataExpander.java
@@ -1,20 +1,21 @@
 package examples.bloghomepagebuilder.builders;
 
+import examples.bloghomepagebuilder.data.ApiAuthValid;
+import examples.bloghomepagebuilder.data.UserDetails;
 import io.appform.databuilderframework.annotations.DataBuilderClassInfo;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
 import io.appform.databuilderframework.model.Data;
-import examples.bloghomepagebuilder.data.ApiAuthValid;
-import examples.bloghomepagebuilder.data.UserDetails;
+import lombok.val;
 
 @DataBuilderClassInfo(produces = UserDetails.class, consumes = {ApiAuthValid.class})
 public class UserDataExpander extends DataBuilder {
 
     @Override
     public Data process(DataBuilderContext context) throws DataBuilderException {
-        ApiAuthValid apiAuthValid = context.getDataSet().accessor().get(ApiAuthValid.class);
-        final String userId = apiAuthValid.getDecryptedUserId();
+        val apiAuthValid = context.getDataSet().accessor().get(ApiAuthValid.class);
+        val userId = apiAuthValid.getDecryptedUserId();
         //Make a DB call and get user details
         return new UserDetails("Santanu Sinha", 777, 0);
     }

--- a/src/test/java/examples/bloghomepagebuilder/controller/HomePageControllerTest.java
+++ b/src/test/java/examples/bloghomepagebuilder/controller/HomePageControllerTest.java
@@ -1,12 +1,13 @@
 package examples.bloghomepagebuilder.controller;
 
-import io.appform.databuilderframework.engine.*;
-import io.appform.databuilderframework.model.DataFlow;
 import com.google.common.base.Stopwatch;
 import examples.bloghomepagebuilder.builders.*;
 import examples.bloghomepagebuilder.data.HomePageRequest;
 import examples.bloghomepagebuilder.data.HomePageResponse;
+import io.appform.databuilderframework.engine.*;
+import io.appform.databuilderframework.model.DataFlow;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -43,10 +44,15 @@ public class HomePageControllerTest {
         runHomePageTest(new MultiThreadedDataFlowExecutor(Executors.newFixedThreadPool(10)));
     }
 
+    @Test
+    public void testHomePageMTOpt() throws Exception {
+        runHomePageTest(new OptimizedMultiThreadedDataFlowExecutor(Executors.newFixedThreadPool(10)));
+    }
+
     private void runHomePageTest(DataFlowExecutor executor) throws Exception {
-        final HomePageRequest request = new HomePageRequest("2321312312", "2323454", "Blah".getBytes());
-        Stopwatch stopwatch = Stopwatch.createStarted();
-        for(long i = 0; i < 100000; i++) {
+        val request = new HomePageRequest("2321312312", "2323454", "Blah".getBytes());
+        val stopwatch = Stopwatch.createStarted();
+        for(long i = 0; i < 100_000; i++) {
             HomePageResponse response = executor.run(homePageDataFlow, request).get(HomePageResponse.class);
             Assert.assertNotNull(response);
             //System.out.println(new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(response));

--- a/src/test/java/examples/bloghomepagebuilder/data/ApiAuthValid.java
+++ b/src/test/java/examples/bloghomepagebuilder/data/ApiAuthValid.java
@@ -1,22 +1,18 @@
 package examples.bloghomepagebuilder.data;
 
 import io.appform.databuilderframework.model.DataAdapter;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
+@EqualsAndHashCode(callSuper = true)
+@Value
 public class ApiAuthValid extends DataAdapter<ApiAuthValid> {
-    private final boolean valid;
-    private final String decryptedUserId;
+    boolean valid;
+    String decryptedUserId;
 
     public ApiAuthValid(boolean valid, String decryptedUserId) {
         super(ApiAuthValid.class);
         this.valid = valid;
         this.decryptedUserId = decryptedUserId;
-    }
-
-    public boolean isValid() {
-        return valid;
-    }
-
-    public String getDecryptedUserId() {
-        return decryptedUserId;
     }
 }

--- a/src/test/java/examples/bloghomepagebuilder/data/BlogId.java
+++ b/src/test/java/examples/bloghomepagebuilder/data/BlogId.java
@@ -1,16 +1,16 @@
 package examples.bloghomepagebuilder.data;
 
 import io.appform.databuilderframework.model.DataAdapter;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
+@Value
+@EqualsAndHashCode(callSuper = true)
 public class BlogId extends DataAdapter<BlogId> {
-    private final String id;
+    String id;
 
     public BlogId(String id) {
         super(BlogId.class);
         this.id = id;
-    }
-
-    public String getId() {
-        return id;
     }
 }

--- a/src/test/java/examples/bloghomepagebuilder/data/BlogPost.java
+++ b/src/test/java/examples/bloghomepagebuilder/data/BlogPost.java
@@ -1,24 +1,18 @@
 package examples.bloghomepagebuilder.data;
 
 import io.appform.databuilderframework.model.DataAdapter;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
+@Value
+@EqualsAndHashCode(callSuper = true)
 public class BlogPost extends DataAdapter<BlogPost> {
-    private final String title;
-    private final byte[] body;
-
+    String title;
+    byte[] body;
 
     public BlogPost(String title, byte[] body) {
         super(BlogPost.class);
         this.title = title;
         this.body = body;
-    }
-
-
-    public String getTitle() {
-        return title;
-    }
-
-    public byte[] getBody() {
-        return body;
     }
 }

--- a/src/test/java/examples/bloghomepagebuilder/data/FollowerList.java
+++ b/src/test/java/examples/bloghomepagebuilder/data/FollowerList.java
@@ -1,18 +1,18 @@
 package examples.bloghomepagebuilder.data;
 
 import io.appform.databuilderframework.model.DataAdapter;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
 import java.util.List;
 
+@Value
+@EqualsAndHashCode(callSuper = true)
 public class FollowerList extends DataAdapter<FollowerList> {
-    private List<String> follower;
+    List<String> follower;
 
     public FollowerList(List<String> follower) {
         super(FollowerList.class);
         this.follower = follower;
-    }
-
-    public List<String> getFollower() {
-        return follower;
     }
 }

--- a/src/test/java/examples/bloghomepagebuilder/data/HomePageRequest.java
+++ b/src/test/java/examples/bloghomepagebuilder/data/HomePageRequest.java
@@ -1,28 +1,20 @@
 package examples.bloghomepagebuilder.data;
 
 import io.appform.databuilderframework.model.DataAdapter;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
+@Value
+@EqualsAndHashCode(callSuper = true)
 public class HomePageRequest extends DataAdapter<HomePageRequest>{
-    private final String requestAuthToken;
-    private final String userAuthToken;
-    private byte[] body;
+    String requestAuthToken;
+    String userAuthToken;
+    byte[] body;
 
     public HomePageRequest(String authToken, String userAuthToken, byte[] body) {
         super(HomePageRequest.class);
         this.requestAuthToken = authToken;
         this.userAuthToken = userAuthToken;
         this.body = body;
-    }
-
-    public String getRequestAuthToken() {
-        return requestAuthToken;
-    }
-
-    public String getUserAuthToken() {
-        return userAuthToken;
-    }
-
-    public byte[] getBody() {
-        return body;
     }
 }

--- a/src/test/java/examples/bloghomepagebuilder/data/HomePageResponse.java
+++ b/src/test/java/examples/bloghomepagebuilder/data/HomePageResponse.java
@@ -1,16 +1,21 @@
 package examples.bloghomepagebuilder.data;
 
 import io.appform.databuilderframework.model.DataAdapter;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
 import java.util.List;
 
+
+@Value
+@EqualsAndHashCode(callSuper = true)
 public class HomePageResponse extends DataAdapter<HomePageResponse> {
-    private final String userName;
-    private final String title;
-    private final byte[] latestBody;
-    private final List<String> followers;
-    private final List<String> posts;
-    private final List<String> tags;
+    String userName;
+    String title;
+    byte[] latestBody;
+    List<String> followers;
+    List<String> posts;
+    List<String> tags;
 
     public HomePageResponse(String userName, String title, byte[] latestBody, List<String> followers, List<String> posts, List<String> tags) {
         super(HomePageResponse.class);
@@ -20,29 +25,5 @@ public class HomePageResponse extends DataAdapter<HomePageResponse> {
         this.followers = followers;
         this.posts = posts;
         this.tags = tags;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public byte[] getLatestBody() {
-        return latestBody;
-    }
-
-    public List<String> getFollowers() {
-        return followers;
-    }
-
-    public List<String> getPosts() {
-        return posts;
-    }
-
-    public List<String> getTags() {
-        return tags;
-    }
-
-    public String getUserName() {
-        return userName;
     }
 }

--- a/src/test/java/examples/bloghomepagebuilder/data/PostList.java
+++ b/src/test/java/examples/bloghomepagebuilder/data/PostList.java
@@ -1,18 +1,18 @@
 package examples.bloghomepagebuilder.data;
 
 import io.appform.databuilderframework.model.DataAdapter;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
 import java.util.List;
 
+@Value
+@EqualsAndHashCode(callSuper = true)
 public class PostList extends DataAdapter<PostList> {
-    private List<String> postTitles;
+    List<String> postTitles;
 
     public PostList(List<String> postTitles) {
         super(PostList.class);
         this.postTitles = postTitles;
-    }
-
-    public List<String> getPostTitles() {
-        return postTitles;
     }
 }

--- a/src/test/java/examples/bloghomepagebuilder/data/RecommendedTags.java
+++ b/src/test/java/examples/bloghomepagebuilder/data/RecommendedTags.java
@@ -1,18 +1,18 @@
 package examples.bloghomepagebuilder.data;
 
 import io.appform.databuilderframework.model.DataAdapter;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
 import java.util.List;
 
+@Value
+@EqualsAndHashCode(callSuper = true)
 public class RecommendedTags extends DataAdapter<RecommendedTags> {
-    private List<String> tags;
+    List<String> tags;
 
     public RecommendedTags(List<String> tags) {
         super(RecommendedTags.class);
         this.tags = tags;
-    }
-
-    public List<String> getTags() {
-        return tags;
     }
 }

--- a/src/test/java/examples/bloghomepagebuilder/data/UserDetails.java
+++ b/src/test/java/examples/bloghomepagebuilder/data/UserDetails.java
@@ -1,28 +1,20 @@
 package examples.bloghomepagebuilder.data;
 
 import io.appform.databuilderframework.model.DataAdapter;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
+@Value
+@EqualsAndHashCode(callSuper = true)
 public class UserDetails extends DataAdapter<UserDetails> {
-    private final String userName;
-    private final int accessPermissionsFlags;
-    private final long joinDate;
+    String userName;
+    int accessPermissionsFlags;
+    long joinDate;
 
     public UserDetails(String userName, int accessPermissionsFlags, long joinDate) {
         super(UserDetails.class);
         this.userName = userName;
         this.accessPermissionsFlags = accessPermissionsFlags;
         this.joinDate = joinDate;
-    }
-
-    public String getUserName() {
-        return userName;
-    }
-
-    public long getJoinDate() {
-        return joinDate;
-    }
-
-    public int getAccessPermissionsFlags() {
-        return accessPermissionsFlags;
     }
 }

--- a/src/test/java/io/appform/databuilderframework/ConditionalFlowAccessTest.java
+++ b/src/test/java/io/appform/databuilderframework/ConditionalFlowAccessTest.java
@@ -1,31 +1,44 @@
 package io.appform.databuilderframework;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import io.appform.databuilderframework.engine.*;
 import io.appform.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
 import io.appform.databuilderframework.model.*;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import org.junit.Assert;
-import org.junit.Before;
+import lombok.val;
 import org.junit.Test;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class ConditionalFlowAccessTest {
-    private DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
-    private DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
-    private ExecutionGraphGenerator executionGraphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
-    private DataFlow dataFlow;
-    private DataFlow dataFlowError = new DataFlow();
+    private final DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager()
+            .register(ImmutableSet.of("A", "B"), "C", "BuilderA", TestBuilderA.class)
+            .registerWithAccess(ImmutableSet.of("C", "D"),
+                                ImmutableSet.of("A"),
+                                "E",
+                                "BuilderB",
+                                ConditionalBuilder.class)
+            .register(ImmutableSet.of("A", "E"), "F", "BuilderC", TestBuilderC.class);
+
+    private final DataFlowExecutor executor
+            = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
+
+    private final DataFlow dataFlow = new DataFlowBuilder()
+            .withMetaDataManager(dataBuilderMetadataManager)
+            .withTargetData("F")
+            .build();
 
     public static final class ConditionalBuilder extends DataBuilder {
 
         @Override
         public Data process(DataBuilderContext context) throws DataBuilderException {
-            DataSetAccessor accessor = new DataSetAccessor(context.getDataSet());
-            Assert.assertTrue(accessor.checkForData("A")); //Assuming in this test without BuilderA Builder is not run and Builder B has access to A
-            Assert.assertFalse(accessor.checkForData("B")); //BuilderB does not have access to A
-            TestDataC dataC = accessor.get("C", TestDataC.class);
-            TestDataD dataD = accessor.get("D", TestDataD.class);
-            if(dataC.getValue().equals("Hello World")
+            val accessor = new DataSetAccessor(context.getDataSet());
+            assertTrue(accessor.checkForData("A")); //Assuming in this test without BuilderA Builder is not run and Builder B has access to A
+            assertFalse(accessor.checkForData("B")); //BuilderB does not have access to A
+            val dataC = accessor.get("C", TestDataC.class);
+            val dataD = accessor.get("D", TestDataD.class);
+            if (dataC.getValue().equals("Hello World")
                     && dataD.getValue().equalsIgnoreCase("this")) {
                 return new TestDataE("Wah wah!!");
             }
@@ -33,70 +46,52 @@ public class ConditionalFlowAccessTest {
         }
     }
 
-    @Before
-    public void setup() throws Exception {
-        dataBuilderMetadataManager.register(ImmutableSet.of("A", "B"), "C", "BuilderA", TestBuilderA.class );
-        dataBuilderMetadataManager.registerWithAccess(ImmutableSet.of("C", "D"), ImmutableSet.of("A"),"E", "BuilderB", ConditionalBuilder.class );
-        dataBuilderMetadataManager.register(ImmutableSet.of("A", "E"), "F", "BuilderC", TestBuilderC.class );
-
-        dataFlow = new DataFlowBuilder()
-                        .withMetaDataManager(dataBuilderMetadataManager)
-                        .withTargetData("F")
-                        .build();
-
-        dataFlowError = new DataFlowBuilder()
-                        .withMetaDataManager(dataBuilderMetadataManager)
-                        .withTargetData("Y")
-                        .build();
-
-    }
-
     @Test
     public void testRunStop() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
+        val dataFlowInstance = new DataFlowInstance();
         dataFlowInstance.setId("testflow");
         dataFlowInstance.setDataFlow(dataFlow);
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello")));
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello")));
             DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertTrue(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().isEmpty());
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataB("Bhai")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("C"));
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataB("Bhai")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("C"));
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertTrue(response.getResponses().isEmpty());
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertTrue(response.getResponses().isEmpty());
         }
 
     }
 
     @Test
     public void testRun() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlow);
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlow);
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertTrue(response.getResponses().isEmpty());
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertTrue(response.getResponses().isEmpty());
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataB("World")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("C"));
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataB("World")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("C"));
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("E"));
-            Assert.assertTrue(response.getResponses().containsKey("F"));
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("E"));
+            assertTrue(response.getResponses().containsKey("F"));
         }
 
     }

--- a/src/test/java/io/appform/databuilderframework/ConditionalFlowTest.java
+++ b/src/test/java/io/appform/databuilderframework/ConditionalFlowTest.java
@@ -1,20 +1,28 @@
 package io.appform.databuilderframework;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import io.appform.databuilderframework.engine.*;
 import io.appform.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
 import io.appform.databuilderframework.model.*;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import org.junit.Assert;
-import org.junit.Before;
+import lombok.val;
 import org.junit.Test;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class ConditionalFlowTest {
-    private DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
-    private DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
-    private ExecutionGraphGenerator executionGraphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
-    private DataFlow dataFlow;
-    private DataFlow dataFlowError = new DataFlow();
+    private final DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager()
+            .register(ImmutableSet.of("A", "B"), "C", "BuilderA", TestBuilderA.class )
+            .register(ImmutableSet.of("C", "D"), "E", "BuilderB", ConditionalBuilder.class )
+            .register(ImmutableSet.of("A", "E"), "F", "BuilderC", TestBuilderC.class );
+
+    private final DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
+
+    private final DataFlow dataFlow= new DataFlowBuilder()
+            .withMetaDataManager(dataBuilderMetadataManager)
+            .withTargetData("F")
+            .build();
 
     public static final class ConditionalBuilder extends DataBuilder {
 
@@ -31,70 +39,52 @@ public class ConditionalFlowTest {
         }
     }
 
-    @Before
-    public void setup() throws Exception {
-        dataBuilderMetadataManager.register(ImmutableSet.of("A", "B"), "C", "BuilderA", TestBuilderA.class );
-        dataBuilderMetadataManager.register(ImmutableSet.of("C", "D"), "E", "BuilderB", ConditionalBuilder.class );
-        dataBuilderMetadataManager.register(ImmutableSet.of("A", "E"), "F", "BuilderC", TestBuilderC.class );
-
-        dataFlow = new DataFlowBuilder()
-                        .withMetaDataManager(dataBuilderMetadataManager)
-                        .withTargetData("F")
-                        .build();
-
-        dataFlowError = new DataFlowBuilder()
-                        .withMetaDataManager(dataBuilderMetadataManager)
-                        .withTargetData("Y")
-                        .build();
-
-    }
-
     @Test
     public void testRunStop() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlow);
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlow);
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertTrue(response.getResponses().isEmpty());
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertTrue(response.getResponses().isEmpty());
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataB("Bhai")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("C"));
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataB("Bhai")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("C"));
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertTrue(response.getResponses().isEmpty());
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertTrue(response.getResponses().isEmpty());
         }
 
     }
 
     @Test
     public void testRun() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlow);
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlow);
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertTrue(response.getResponses().isEmpty());
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertTrue(response.getResponses().isEmpty());
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataB("World")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("C"));
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataB("World")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("C"));
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("E"));
-            Assert.assertTrue(response.getResponses().containsKey("F"));
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("E"));
+            assertTrue(response.getResponses().containsKey("F"));
         }
 
     }

--- a/src/test/java/io/appform/databuilderframework/DataBuilderMetadataManagerOptionalTest.java
+++ b/src/test/java/io/appform/databuilderframework/DataBuilderMetadataManagerOptionalTest.java
@@ -1,25 +1,33 @@
 package io.appform.databuilderframework;
 
+import com.google.common.collect.ImmutableSet;
 import io.appform.databuilderframework.engine.DataBuilderFrameworkException;
 import io.appform.databuilderframework.engine.DataBuilderMetadataManager;
-import com.google.common.collect.ImmutableSet;
-
+import lombok.val;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class DataBuilderMetadataManagerOptionalTest {
     @Test
     public void testRegister() throws Exception {
-        DataBuilderMetadataManager dataBuilderMetadataManager
-                                        = new DataBuilderMetadataManager();
-        dataBuilderMetadataManager.registerWithOptionals(ImmutableSet.of("A", "B"),ImmutableSet.of("G"), "C", "BuilderA", TestBuilderA.class );
+        val dataBuilderMetadataManager = new DataBuilderMetadataManager()
+                .registerWithOptionals(ImmutableSet.of("A", "B"),
+                                       ImmutableSet.of("G"),
+                                       "C",
+                                       "BuilderA",
+                                       TestBuilderA.class);
         try {
-            dataBuilderMetadataManager.registerWithOptionals(ImmutableSet.of("A", "B"),ImmutableSet.of("G"), "C", "BuilderA", TestBuilderB.class );
-        } catch (DataBuilderFrameworkException e) {
-            if(e.getErrorCode() == DataBuilderFrameworkException.ErrorCode.BUILDER_EXISTS) {
-                return;
-            }
+            dataBuilderMetadataManager.registerWithOptionals(ImmutableSet.of("A", "B"),
+                                                             ImmutableSet.of("G"),
+                                                             "C",
+                                                             "BuilderA",
+                                                             TestBuilderB.class);
+        }
+        catch (DataBuilderFrameworkException e) {
+            assertEquals(DataBuilderFrameworkException.ErrorCode.BUILDER_EXISTS, e.getErrorCode());
+            return;
         }
         fail("Duplicate error should have come");
     }

--- a/src/test/java/io/appform/databuilderframework/DataBuilderMetadataManagerTest.java
+++ b/src/test/java/io/appform/databuilderframework/DataBuilderMetadataManagerTest.java
@@ -1,24 +1,25 @@
 package io.appform.databuilderframework;
 
+import com.google.common.collect.ImmutableSet;
 import io.appform.databuilderframework.engine.DataBuilderFrameworkException;
 import io.appform.databuilderframework.engine.DataBuilderMetadataManager;
-import com.google.common.collect.ImmutableSet;
+import lombok.val;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class DataBuilderMetadataManagerTest {
     @Test
     public void testRegister() throws Exception {
-        DataBuilderMetadataManager dataBuilderMetadataManager
-                                        = new DataBuilderMetadataManager();
-        dataBuilderMetadataManager.register(ImmutableSet.of("A", "B"), "C", "BuilderA", TestBuilderA.class );
+        val dataBuilderMetadataManager = new DataBuilderMetadataManager()
+                .register(ImmutableSet.of("A", "B"), "C", "BuilderA", TestBuilderA.class);
         try {
-            dataBuilderMetadataManager.register(ImmutableSet.of("A", "B"), "C", "BuilderA", TestBuilderB.class );
-        } catch (DataBuilderFrameworkException e) {
-            if(e.getErrorCode() == DataBuilderFrameworkException.ErrorCode.BUILDER_EXISTS) {
-                return;
-            }
+            dataBuilderMetadataManager.register(ImmutableSet.of("A", "B"), "C", "BuilderA", TestBuilderB.class);
+        }
+        catch (DataBuilderFrameworkException e) {
+            assertEquals(DataBuilderFrameworkException.ErrorCode.BUILDER_EXISTS, e.getErrorCode());
+            return;
         }
         fail("Duplicate error should have come");
     }

--- a/src/test/java/io/appform/databuilderframework/DataExecutionListenerContextTest.java
+++ b/src/test/java/io/appform/databuilderframework/DataExecutionListenerContextTest.java
@@ -1,102 +1,128 @@
 package io.appform.databuilderframework;
 
+import com.google.common.collect.Lists;
 import io.appform.databuilderframework.engine.*;
 import io.appform.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
 import io.appform.databuilderframework.model.*;
-import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @Slf4j
 public class DataExecutionListenerContextTest {
-	
-	private static final String KEY = "key";
-	private static final String VALUE = "value";
-    private static class TestListenerWithContextCheck implements DataBuilderExecutionListener {
+
+    private static final String KEY = "key";
+    private static final String VALUE = "value";
+
+    private static final class TestListenerWithContextCheck implements DataBuilderExecutionListener {
+        private boolean allTestsPassed = true;
 
         @Override
-        public void preProcessing(DataFlowInstance dataFlowInstance,
-                                  DataDelta dataDelta) throws Exception {
+        public void preProcessing(
+                DataFlowInstance dataFlowInstance,
+                DataDelta dataDelta) throws Exception {
             log.info("Being called for: {}", dataFlowInstance.getId());
         }
 
         @Override
-        public void beforeExecute(DataBuilderContext builderContext,
-        						  DataFlowInstance dataFlowInstance,
-                                  DataBuilderMeta builderToBeApplied,
-                                  DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
-        	Assert.assertNotNull(builderContext);
-        	Assert.assertEquals(builderContext.getContextData(KEY, String.class), VALUE);
+        public void beforeExecute(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
+            try {
+                Assert.assertNotNull(builderContext);
+                assertEquals(VALUE, builderContext.getContextData(KEY, String.class));
+            }
+            catch (Exception e) {
+                allTestsPassed = false;
+                throw e;
+            }
         }
 
         @Override
-        public void afterExecute(DataBuilderContext builderContext,
-        						 DataFlowInstance dataFlowInstance,
-                                 DataBuilderMeta builderToBeApplied,
-                                 DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
-        	Assert.assertNotNull(builderContext);
-        	Assert.assertEquals(builderContext.getContextData(KEY, String.class), VALUE);
+        public void afterExecute(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
+            try {
+                Assert.assertNotNull(builderContext);
+                assertEquals(VALUE, builderContext.getContextData(KEY, String.class));
+            }
+            catch (Exception e) {
+                allTestsPassed = false;
+                throw e;
+            }
         }
 
         @Override
-        public void afterException(DataBuilderContext builderContext,
-        						   DataFlowInstance dataFlowInstance,
-                                   DataBuilderMeta builderToBeApplied,
-                                   DataDelta dataDelta,
-                                   Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
-        	Assert.assertNotNull(builderContext);
-        	Assert.assertEquals(builderContext.getContextData(KEY, String.class), VALUE);
+        public void afterException(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta,
+                Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
+            try {
+                Assert.assertNotNull(builderContext);
+                assertEquals(VALUE, builderContext.getContextData(KEY, String.class));
+            }
+            catch (Exception e) {
+                allTestsPassed = false;
+                throw e;
+            }
         }
 
 
         @Override
-        public void postProcessing(DataFlowInstance dataFlowInstance,
-                                   DataDelta dataDelta, DataExecutionResponse response,
-                                   Throwable frameworkException) throws Exception  {
+        public void postProcessing(
+                DataFlowInstance dataFlowInstance,
+                DataDelta dataDelta, DataExecutionResponse response,
+                Throwable frameworkException) throws Exception {
             log.info("Being called for: {}", dataFlowInstance.getId());
         }
     }
 
-    private DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
-    private DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
-    private DataFlow dataFlow = new DataFlow();
+    private final DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
+    private final DataFlowExecutor executor
+            = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
+    private final DataFlow dataFlow = new DataFlowBuilder()
+            .withAnnotatedDataBuilder(TestBuilderA.class)
+            .withAnnotatedDataBuilder(TestBuilderB.class)
+            .withAnnotatedDataBuilder(TestBuilderC.class)
+            .withTargetData("F")
+            .build();
+    private final TestListenerWithContextCheck listener = new TestListenerWithContextCheck();
 
     @Before
     public void setup() throws Exception {
-        dataFlow = new DataFlowBuilder()
-                .withAnnotatedDataBuilder(TestBuilderA.class)
-                .withAnnotatedDataBuilder(TestBuilderB.class)
-                .withAnnotatedDataBuilder(TestBuilderC.class)
-                .withTargetData("F")
-                .build();
-
-        executor.registerExecutionListener(new TestListenerWithContextCheck());
+        executor.registerExecutionListener(listener);
     }
-
 
     @Test
     public void testBuilderRunWithContextBeingPassed() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
+        val dataFlowInstance = new DataFlowInstance();
         dataFlowInstance.setId("testflow");
         dataFlowInstance.setDataFlow(dataFlow);
         {
-        	DataBuilderContext context = new DataBuilderContext();
-        	context.saveContextData(KEY, VALUE);
-            DataDelta dataDelta = new DataDelta(Lists.newArrayList(
-                                            new TestDataA("Hello"), new TestDataB("World"),
-                                            new TestDataD("this"), new TestDataG("Hmmm")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertEquals(3, response.getResponses().size());
-            Assert.assertTrue(response.getResponses().containsKey("C"));
-            Assert.assertTrue(response.getResponses().containsKey("E"));
-            Assert.assertTrue(response.getResponses().containsKey("F"));
+            val context = new DataBuilderContext().saveContextData(KEY, VALUE);
+            val dataDelta = new DataDelta(Lists.newArrayList(
+                    new TestDataA("Hello"), new TestDataB("World"),
+                    new TestDataD("this"), new TestDataG("Hmmm")));
+            val response = executor.run(context, dataFlowInstance, dataDelta);
+            assertEquals(3, response.getResponses().size());
+            assertTrue(response.getResponses().containsKey("C"));
+            assertTrue(response.getResponses().containsKey("E"));
+            assertTrue(response.getResponses().containsKey("F"));
         }
+        assertTrue(listener.allTestsPassed);
     }
 
 }

--- a/src/test/java/io/appform/databuilderframework/DataFlowExecutorTest.java
+++ b/src/test/java/io/appform/databuilderframework/DataFlowExecutorTest.java
@@ -1,142 +1,159 @@
 package io.appform.databuilderframework;
 
+import com.google.common.collect.Lists;
 import io.appform.databuilderframework.engine.*;
 import io.appform.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
 import io.appform.databuilderframework.model.*;
-import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Assert;
-import org.junit.Before;
+import lombok.val;
 import org.junit.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 @Slf4j
 public class DataFlowExecutorTest {
     private static class TestListener implements DataBuilderExecutionListener {
 
         @Override
-        public void preProcessing(DataFlowInstance dataFlowInstance,
-                                   DataDelta dataDelta) throws Exception {
+        public void preProcessing(
+                DataFlowInstance dataFlowInstance,
+                DataDelta dataDelta) {
             log.info("Being called for: {}", dataFlowInstance.getId());
         }
 
         @Override
-        public void beforeExecute(DataBuilderContext builderContext,
-        						  DataFlowInstance dataFlowInstance,
-                                  DataBuilderMeta builderToBeApplied,
-                                  DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
+        public void beforeExecute(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
             log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
         }
 
         @Override
-        public void afterExecute(DataBuilderContext builderContext,
-        						 DataFlowInstance dataFlowInstance,
-                                 DataBuilderMeta builderToBeApplied,
-                                 DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
+        public void afterExecute(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
             log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
         }
 
         @Override
-        public void afterException(DataBuilderContext builderContext,
-        						   DataFlowInstance dataFlowInstance,
-                                   DataBuilderMeta builderToBeApplied,
-                                   DataDelta dataDelta,
-                                   Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
+        public void afterException(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta,
+                Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
             log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
         }
 
         @Override
-        public void postProcessing(DataFlowInstance dataFlowInstance,
-                                   DataDelta dataDelta,
-                                   DataExecutionResponse response,
-                                   Throwable frameworkException) throws Exception {
+        public void postProcessing(
+                DataFlowInstance dataFlowInstance,
+                DataDelta dataDelta,
+                DataExecutionResponse response,
+                Throwable frameworkException) throws Exception {
             log.info("Being called for: {}", dataFlowInstance.getId());
         }
     }
+
     private static class TestListenerBeforeExecutionError implements DataBuilderExecutionListener {
 
         @Override
-        public void preProcessing(DataFlowInstance dataFlowInstance,
-                                  DataDelta dataDelta) throws Exception {
+        public void preProcessing(
+                DataFlowInstance dataFlowInstance,
+                DataDelta dataDelta) throws Exception {
             log.info("Being called for: {}", dataFlowInstance.getId());
         }
+
         @Override
-        public void beforeExecute(DataBuilderContext builderContext,
-        						  DataFlowInstance dataFlowInstance,
-                                  DataBuilderMeta builderToBeApplied,
-                                  DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
+        public void beforeExecute(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
             //System.out.println(builderToBeApplied.getName() + " being called for: " + dataFlowInstance.getId());
             throw new Exception("Blah blah");
         }
 
         @Override
-        public void afterExecute(DataBuilderContext builderContext,
-        						 DataFlowInstance dataFlowInstance,
-                                 DataBuilderMeta builderToBeApplied,
-                                 DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
+        public void afterExecute(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
             log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
         }
 
         @Override
-        public void afterException(DataBuilderContext builderContext,
-        						   DataFlowInstance dataFlowInstance,
-                                   DataBuilderMeta builderToBeApplied,
-                                   DataDelta dataDelta,
-                                   Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
+        public void afterException(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta,
+                Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
             log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
         }
 
         @Override
-        public void postProcessing(DataFlowInstance dataFlowInstance,
-                                   DataDelta dataDelta,
-                                   DataExecutionResponse response,
-                                   Throwable frameworkException) throws Exception {
+        public void postProcessing(
+                DataFlowInstance dataFlowInstance,
+                DataDelta dataDelta,
+                DataExecutionResponse response,
+                Throwable frameworkException) throws Exception {
             log.info("Being called for: {}", dataFlowInstance.getId());
         }
     }
+
     private static class TestListenerAfterExecutionError implements DataBuilderExecutionListener {
 
         @Override
-        public void preProcessing(DataFlowInstance dataFlowInstance,
-                                  DataDelta dataDelta) throws Exception {
+        public void preProcessing(
+                DataFlowInstance dataFlowInstance,
+                DataDelta dataDelta) throws Exception {
             log.info("Being called for: {}", dataFlowInstance.getId());
         }
 
         @Override
-        public void beforeExecute(DataBuilderContext builderContext,
-        						  DataFlowInstance dataFlowInstance,
-                                  DataBuilderMeta builderToBeApplied,
-                                  DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
+        public void beforeExecute(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
             log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
         }
 
         @Override
-        public void afterExecute(DataBuilderContext builderContext,
-        						 DataFlowInstance dataFlowInstance,
-                                 DataBuilderMeta builderToBeApplied,
-                                 DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
+        public void afterExecute(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
             //System.out.println(builderToBeApplied.getName() + " called for: " + dataFlowInstance.getId());
             throw new Exception("Blah blah");
 
         }
 
         @Override
-        public void afterException(DataBuilderContext builderContext,
-        						   DataFlowInstance dataFlowInstance,
-                                   DataBuilderMeta builderToBeApplied,
-                                   DataDelta dataDelta,
-                                   Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
+        public void afterException(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta,
+                Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
             log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
         }
 
         @Override
-        public void postProcessing(DataFlowInstance dataFlowInstance,
-                                   DataDelta dataDelta,
-                                   DataExecutionResponse response,
-                                   Throwable frameworkException) throws Exception {
+        public void postProcessing(
+                DataFlowInstance dataFlowInstance,
+                DataDelta dataDelta,
+                DataExecutionResponse response,
+                Throwable frameworkException) throws Exception {
             log.info("Being called for: {}", dataFlowInstance.getId());
         }
     }
@@ -144,164 +161,153 @@ public class DataFlowExecutorTest {
     private static class TestListenerAfterExceptionError implements DataBuilderExecutionListener {
 
         @Override
-        public void preProcessing(DataFlowInstance dataFlowInstance,
-                                  DataDelta dataDelta) throws Exception {
+        public void preProcessing(
+                DataFlowInstance dataFlowInstance,
+                DataDelta dataDelta) throws Exception {
             log.info("Being called for: {}", dataFlowInstance.getId());
         }
 
         @Override
-        public void beforeExecute(DataBuilderContext builderContext,
-        						  DataFlowInstance dataFlowInstance,
-                                  DataBuilderMeta builderToBeApplied,
-                                  DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
+        public void beforeExecute(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
             log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
         }
 
         @Override
-        public void afterExecute(DataBuilderContext builderContext,
-        						 DataFlowInstance dataFlowInstance,
-                                 DataBuilderMeta builderToBeApplied,
-                                 DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
+        public void afterExecute(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
             log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
 
         }
 
         @Override
-        public void afterException(DataBuilderContext builderContext,
-        						   DataFlowInstance dataFlowInstance,
-                                   DataBuilderMeta builderToBeApplied,
-                                   DataDelta dataDelta,
-                                   Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
+        public void afterException(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta,
+                Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
             //System.out.println(builderToBeApplied.getName() + " called for: " + dataFlowInstance.getId());
             throw new Exception("Blah blah");
         }
+
         @Override
-        public void postProcessing(DataFlowInstance dataFlowInstance,
-                                   DataDelta dataDelta,
-                                   DataExecutionResponse response,
-                                   Throwable frameworkException) throws Exception {
+        public void postProcessing(
+                DataFlowInstance dataFlowInstance,
+                DataDelta dataDelta,
+                DataExecutionResponse response,
+                Throwable frameworkException) throws Exception {
             log.info("Being called for: {}", dataFlowInstance.getId());
         }
     }
 
-    private DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
-    private DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
-    private DataFlow dataFlow = new DataFlow();
-    private DataFlow dataFlowError = new DataFlow();
-    private DataFlow dataFlowValidationError = new DataFlow();
-    private DataFlow dataFlowValidationErrorWithPartialData = new DataFlow();
-
-    @Before
-    public void setup() throws Exception {
-        dataFlow = new DataFlowBuilder()
-                .withAnnotatedDataBuilder(TestBuilderA.class)
-                .withAnnotatedDataBuilder(TestBuilderB.class)
-                .withAnnotatedDataBuilder(TestBuilderC.class)
-                .withTargetData("F")
-                .build();
-
-        dataFlowError = new DataFlowBuilder()
-                .withAnnotatedDataBuilder(TestBuilderError.class)
-                .withTargetData("Y")
-                .build();
-        executor.registerExecutionListener(new TestListener());
-        executor.registerExecutionListener(new TestListenerBeforeExecutionError());
-        executor.registerExecutionListener(new TestListenerAfterExecutionError());
-        executor.registerExecutionListener(new TestListenerAfterExceptionError());
-
-        dataFlowValidationError = new DataFlowBuilder()
-                .withAnnotatedDataBuilder(TestBuilderDataValidationError.class)
-                .withTargetData("Y")
-                .build();
-        executor.registerExecutionListener(new TestListener());
-        executor.registerExecutionListener(new TestListenerBeforeExecutionError());
-        executor.registerExecutionListener(new TestListenerAfterExecutionError());
-        executor.registerExecutionListener(new TestListenerAfterExceptionError());
-
-        dataFlowValidationErrorWithPartialData = new DataFlowBuilder()
-                .withAnnotatedDataBuilder(TestBuilderA.class)
-                .withAnnotatedDataBuilder(TestBuilderDataValidationError.class)
-                .withTargetData("Y")
-                .build();
-        executor.registerExecutionListener(new TestListener());
-        executor.registerExecutionListener(new TestListenerBeforeExecutionError());
-        executor.registerExecutionListener(new TestListenerAfterExecutionError());
-        executor.registerExecutionListener(new TestListenerAfterExceptionError());
-
-    }
+    private final DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
+    private final DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(
+            dataBuilderMetadataManager))
+            .registerExecutionListener(new TestListener())
+            .registerExecutionListener(new TestListenerBeforeExecutionError())
+            .registerExecutionListener(new TestListenerAfterExecutionError())
+            .registerExecutionListener(new TestListenerAfterExceptionError());
+    private final DataFlow dataFlow = new DataFlowBuilder()
+            .withAnnotatedDataBuilder(TestBuilderA.class)
+            .withAnnotatedDataBuilder(TestBuilderB.class)
+            .withAnnotatedDataBuilder(TestBuilderC.class)
+            .withTargetData("F")
+            .build();
+    private final DataFlow dataFlowError = new DataFlowBuilder()
+            .withAnnotatedDataBuilder(TestBuilderError.class)
+            .withTargetData("Y")
+            .build();
+    private final DataFlow dataFlowValidationError = new DataFlowBuilder()
+            .withAnnotatedDataBuilder(TestBuilderDataValidationError.class)
+            .withTargetData("Y")
+            .build();
+    private final DataFlow dataFlowValidationErrorWithPartialData = new DataFlowBuilder()
+            .withAnnotatedDataBuilder(TestBuilderA.class)
+            .withAnnotatedDataBuilder(TestBuilderDataValidationError.class)
+            .withTargetData("Y")
+            .build();
 
     @Test
     public void testRunThreeSteps() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlow);
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlow);
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertTrue(response.getResponses().isEmpty());
+            val dataDelta = new DataDelta(Lists.newArrayList(new TestDataA("Hello")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertTrue(response.getResponses().isEmpty());
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataB("World")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("C"));
+            val dataDelta = new DataDelta(Lists.newArrayList(new TestDataB("World")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("C"));
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("E"));
-            Assert.assertTrue(response.getResponses().containsKey("F"));
+            val dataDelta = new DataDelta(Lists.newArrayList(new TestDataD("this")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("E"));
+            assertTrue(response.getResponses().containsKey("F"));
         }
     }
 
     @Test
     public void testRunTwoSteps() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlow);
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlow);
         {
-            DataDelta dataDelta = new DataDelta(Lists.newArrayList(new TestDataA("Hello"), new TestDataB("World")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("C"));
+            val dataDelta = new DataDelta(Lists.newArrayList(new TestDataA("Hello"), new TestDataB("World")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("C"));
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("E"));
-            Assert.assertTrue(response.getResponses().containsKey("F"));
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("E"));
+            assertTrue(response.getResponses().containsKey("F"));
         }
     }
+
     @Test
     public void testRunSingleStep() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlow);
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlow);
         {
-            DataDelta dataDelta = new DataDelta(Lists.newArrayList(
-                                            new TestDataA("Hello"), new TestDataB("World"),
-                                            new TestDataD("this"), new TestDataG("Hmmm")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertEquals(3, response.getResponses().size());
-            Assert.assertTrue(response.getResponses().containsKey("C"));
-            Assert.assertTrue(response.getResponses().containsKey("E"));
-            Assert.assertTrue(response.getResponses().containsKey("F"));
+            val dataDelta = new DataDelta(Lists.newArrayList(
+                    new TestDataA("Hello"), new TestDataB("World"),
+                    new TestDataD("this"), new TestDataG("Hmmm")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertEquals(3, response.getResponses().size());
+            assertTrue(response.getResponses().containsKey("C"));
+            assertTrue(response.getResponses().containsKey("E"));
+            assertTrue(response.getResponses().containsKey("F"));
         }
     }
 
     @Test
     public void testRunError() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlowError);
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlowError);
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataX("Hello")));
+            val dataDelta = new DataDelta(Lists.newArrayList(new TestDataX("Hello")));
             try {
                 executor.run(dataFlowInstance, dataDelta);
-            } catch (Exception e) {
-                Assert.assertEquals("TestError", e.getCause().getMessage());
+            }
+            catch (Exception e) {
+                assertEquals("TestError", e.getCause().getMessage());
                 return;
             }
             fail("Should have thrown exception");
@@ -317,7 +323,8 @@ public class DataFlowExecutorTest {
             DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataX("Hello"), null));
             try {
                 executor.run(dataFlowInstance, dataDelta);
-            } catch (Exception e) {
+            }
+            catch (Exception e) {
                 return;
             }
             fail("Should have thrown exception");
@@ -333,8 +340,9 @@ public class DataFlowExecutorTest {
             DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataC("Hello")));
             try {
                 executor.run(dataFlowInstance, dataDelta);
-            } catch (Exception e) {
-                Assert.assertEquals("DataValidationError", e.getCause().getMessage());
+            }
+            catch (Exception e) {
+                assertEquals("DataValidationError", e.getCause().getMessage());
                 return;
             }
             fail("Should have thrown exception");
@@ -348,17 +356,19 @@ public class DataFlowExecutorTest {
         dataFlowInstance.setId("testflow");
         dataFlowInstance.setDataFlow(dataFlowValidationErrorWithPartialData);
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello"), new TestDataB("World")));
+            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello"),
+                                                                         new TestDataB("World")));
             try {
-                 response = executor.run(dataFlowInstance, dataDelta);
-            } catch (DataValidationException e) {
+                response = executor.run(dataFlowInstance, dataDelta);
+            }
+            catch (DataValidationException e) {
                 DataExecutionResponse dataExecutionResponse = e.getResponse();
-                Assert.assertTrue(dataExecutionResponse.getResponses().containsKey("C"));
+                assertTrue(dataExecutionResponse.getResponses().containsKey("C"));
                 return;
             }
             fail("Should have thrown exception");
         }
     }
-    
-    
+
+
 }

--- a/src/test/java/io/appform/databuilderframework/DataFlowWithAccessesExecutorTest.java
+++ b/src/test/java/io/appform/databuilderframework/DataFlowWithAccessesExecutorTest.java
@@ -1,69 +1,68 @@
 package io.appform.databuilderframework;
 
+import com.google.common.collect.Lists;
 import io.appform.databuilderframework.engine.*;
 import io.appform.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
 import io.appform.databuilderframework.model.*;
-import com.google.common.collect.Lists;
-import org.junit.Before;
+import lombok.val;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class DataFlowWithAccessesExecutorTest {
 
-    private DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
-    private DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
-    private DataFlow dataFlow = new DataFlow();
+    private final DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
+    private final DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(
+            dataBuilderMetadataManager));
+    private final DataFlow dataFlow = new DataFlowBuilder()
+            .withAnnotatedDataBuilder(TestBuilderAccesses.class)
+            .withTargetData("X")
+            .build();
 
-    @Before
-    public void setup() throws Exception {
-        dataFlow = new DataFlowBuilder()
-                .withAnnotatedDataBuilder(TestBuilderAccesses.class)
-                .withTargetData("X")
-                .build();
-    }
 
     @Test
     public void withoutAnyAccessData() throws DataBuilderFrameworkException, DataValidationException {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlow);
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlow);
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello")));
+            val response = executor.run(dataFlowInstance, dataDelta);
             assertFalse(response.getResponses().isEmpty());
             assertTrue(response.getResponses().containsKey("X"));
             if (response.getResponses().get("X") instanceof TestDataX) {
-                assertTrue(((TestDataX) response.getResponses().get("X")).getValue().equals("FALSE"));
-            } else {
-                assertTrue("X not instance of TestDataX", false);
+                assertEquals("FALSE", ((TestDataX) response.getResponses().get("X")).getValue());
+            }
+            else {
+                fail("X not instance of TestDataX");
             }
         }
     }
 
     @Test
     public void withAccessData() throws DataBuilderFrameworkException, DataValidationException {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlow);
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlow);
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello"), new TestDataD("DD")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello"), new TestDataD("DD")));
+            val response = executor.run(dataFlowInstance, dataDelta);
             assertFalse(response.getResponses().isEmpty());
             assertTrue(response.getResponses().containsKey("X"));
             if (response.getResponses().get("X") instanceof TestDataX) {
-                assertTrue(((TestDataX) response.getResponses().get("X")).getValue().equals("TRUE"));
-            } else {
-                assertTrue("X not instance of TestDataX", false);
+                assertEquals("TRUE", ((TestDataX) response.getResponses().get("X")).getValue());
+            }
+            else {
+                fail("X not instance of TestDataX");
             }
         }
     }
+
     @Test
     public void withoutOnlyAccessData() throws DataBuilderFrameworkException, DataValidationException {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlow);
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlow);
         {
             DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("Hello")));
             DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);

--- a/src/test/java/io/appform/databuilderframework/DataFlowWithOptionalExecutorTest.java
+++ b/src/test/java/io/appform/databuilderframework/DataFlowWithOptionalExecutorTest.java
@@ -1,277 +1,106 @@
 package io.appform.databuilderframework;
 
-import io.appform.databuilderframework.engine.*;
+import com.google.common.collect.Lists;
+import io.appform.databuilderframework.engine.DataBuilderMetadataManager;
+import io.appform.databuilderframework.engine.DataFlowBuilder;
+import io.appform.databuilderframework.engine.DataFlowExecutor;
+import io.appform.databuilderframework.engine.SimpleDataFlowExecutor;
 import io.appform.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
 import io.appform.databuilderframework.model.*;
-import com.google.common.collect.Lists;
-
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Assert;
-import org.junit.Before;
+import lombok.val;
 import org.junit.Test;
 
-import java.util.Map;
-
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @Slf4j
 public class DataFlowWithOptionalExecutorTest {
-    private static class TestListener implements DataBuilderExecutionListener {
 
-        @Override
-        public void preProcessing(DataFlowInstance dataFlowInstance,
-                                  DataDelta dataDelta) throws Exception {
-            log.info("Being called for: {}", dataFlowInstance.getId());
-        }
-
-        @Override
-        public void beforeExecute(DataBuilderContext builderContext,
-        						  DataFlowInstance dataFlowInstance,
-                                  DataBuilderMeta builderToBeApplied,
-                                  DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
-            log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
-        }
-
-        @Override
-        public void afterExecute(DataBuilderContext builderContext,
-        						 DataFlowInstance dataFlowInstance,
-                                 DataBuilderMeta builderToBeApplied,
-                                 DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
-            log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
-        }
-
-        @Override
-        public void afterException(DataBuilderContext builderContext,
-        						   DataFlowInstance dataFlowInstance,
-                                   DataBuilderMeta builderToBeApplied,
-                                   DataDelta dataDelta,
-                                   Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
-            log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
-        }
-
-        @Override
-        public void postProcessing(DataFlowInstance dataFlowInstance,
-                                   DataDelta dataDelta, DataExecutionResponse response,
-                                   Throwable frameworkException) throws Exception {
-            log.info("Being called for: {}", dataFlowInstance.getId());
-        }
-    }
-    private static class TestListenerBeforeExecutionError implements DataBuilderExecutionListener {
-
-        @Override
-        public void preProcessing(DataFlowInstance dataFlowInstance,
-                                  DataDelta dataDelta) throws Exception {
-            log.info("Being called for: {}", dataFlowInstance.getId());
-        }
-
-        @Override
-        public void beforeExecute(DataBuilderContext builderContext,
-        						  DataFlowInstance dataFlowInstance,
-                                  DataBuilderMeta builderToBeApplied,
-                                  DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
-            //System.out.println(builderToBeApplied.getName() + " being called for: " + dataFlowInstance.getId());
-            throw new Exception("Blah blah");
-        }
-
-        @Override
-        public void afterExecute(DataBuilderContext builderContext,
-        						 DataFlowInstance dataFlowInstance,
-                                 DataBuilderMeta builderToBeApplied,
-                                 DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
-            log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
-        }
-
-        @Override
-        public void afterException(DataBuilderContext builderContext,
-        						   DataFlowInstance dataFlowInstance,
-                                   DataBuilderMeta builderToBeApplied,
-                                   DataDelta dataDelta,
-                                   Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
-            log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
-        }
-
-        @Override
-        public void postProcessing(DataFlowInstance dataFlowInstance,
-                                   DataDelta dataDelta, DataExecutionResponse response,
-                                   Throwable frameworkException) throws Exception {
-            log.info("Being called for: {}", dataFlowInstance.getId());
-        }
-    }
-    private static class TestListenerAfterExecutionError implements DataBuilderExecutionListener {
-
-        @Override
-        public void preProcessing(DataFlowInstance dataFlowInstance,
-                                  DataDelta dataDelta) throws Exception {
-            log.info("Being called for: {}", dataFlowInstance.getId());
-        }
-
-        @Override
-        public void beforeExecute(DataBuilderContext builderContext,
-        						  DataFlowInstance dataFlowInstance,
-                                  DataBuilderMeta builderToBeApplied,
-                                  DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
-            log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
-        }
-
-        @Override
-        public void afterExecute(DataBuilderContext builderContext,
-        						 DataFlowInstance dataFlowInstance,
-                                 DataBuilderMeta builderToBeApplied,
-                                 DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
-            //System.out.println(builderToBeApplied.getName() + " called for: " + dataFlowInstance.getId());
-            throw new Exception("Blah blah");
-
-        }
-
-        @Override
-        public void afterException(DataBuilderContext builderContext,
-        						   DataFlowInstance dataFlowInstance,
-                                   DataBuilderMeta builderToBeApplied,
-                                   DataDelta dataDelta,
-                                   Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
-            log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
-        }
-
-        @Override
-        public void postProcessing(DataFlowInstance dataFlowInstance,
-                                   DataDelta dataDelta, DataExecutionResponse response,
-                                   Throwable frameworkException) throws Exception {
-            log.info("Being called for: {}", dataFlowInstance.getId());
-        }
-    }
-
-    private static class TestListenerAfterExceptionError implements DataBuilderExecutionListener {
-
-        @Override
-        public void preProcessing(DataFlowInstance dataFlowInstance,
-                                  DataDelta dataDelta) throws Exception {
-            log.info("Being called for: {}", dataFlowInstance.getId());
-        }
-
-        @Override
-        public void beforeExecute(DataBuilderContext builderContext,
-        						  DataFlowInstance dataFlowInstance,
-                                  DataBuilderMeta builderToBeApplied,
-                                  DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
-            log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
-        }
-
-        @Override
-        public void afterExecute(DataBuilderContext builderContext,
-        						 DataFlowInstance dataFlowInstance,
-                                 DataBuilderMeta builderToBeApplied,
-                                 DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
-            log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
-
-        }
-
-        @Override
-        public void afterException(DataBuilderContext builderContext,
-        						   DataFlowInstance dataFlowInstance,
-                                   DataBuilderMeta builderToBeApplied,
-                                   DataDelta dataDelta,
-                                   Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
-            //System.out.println(builderToBeApplied.getName() + " called for: " + dataFlowInstance.getId());
-            throw new Exception("Blah blah");
-        }
-        @Override
-        public void postProcessing(DataFlowInstance dataFlowInstance,
-                                   DataDelta dataDelta, DataExecutionResponse response,
-                                   Throwable frameworkException) throws Exception {
-            log.info("Being called for: {}", dataFlowInstance.getId());
-        }
-    }
-
-    private DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
-    private DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
-    private DataFlow dataFlow = new DataFlow();
-
-    @Before
-    public void setup() throws Exception {
-        dataFlow = new DataFlowBuilder()
-                .withAnnotatedDataBuilder(TestBuilderOptional.class)
-                .withAnnotatedDataBuilder(TestBuilderB.class)
-                .withAnnotatedDataBuilder(TestBuilderC.class)
-                .withTargetData("F")
-                .build();
-
-    }
+    private final DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
+    private final DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
+    private final DataFlow dataFlow  = new DataFlowBuilder()
+            .withAnnotatedDataBuilder(TestBuilderOptional.class)
+            .withAnnotatedDataBuilder(TestBuilderB.class)
+            .withAnnotatedDataBuilder(TestBuilderC.class)
+            .withTargetData("F")
+            .build();
 
     @Test
     public void testRunWithoutOptional() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlow);
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlow);
         {
-            DataDelta dataDelta = new DataDelta(new TestDataB("World"));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertTrue(response.getResponses().isEmpty());
-            Assert.assertFalse(response.getResponses().containsKey("C"));
+            val dataDelta = new DataDelta(new TestDataB("World"));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertTrue(response.getResponses().isEmpty());
+            assertFalse(response.getResponses().containsKey("C"));
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello World")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("C"));
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello World")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("C"));
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("E"));
-            Assert.assertTrue(response.getResponses().containsKey("F"));
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("E"));
+            assertTrue(response.getResponses().containsKey("F"));
         }
     }
 
     @Test
     public void testRunOptional() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlow);
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlow);
         
         {
-            DataDelta dataDelta = new DataDelta(new TestDataA("Hello"));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertTrue(response.getResponses().isEmpty());
-            Assert.assertFalse(response.getResponses().containsKey("C"));
+            val dataDelta = new DataDelta(new TestDataA("Hello"));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertTrue(response.getResponses().isEmpty());
+            assertFalse(response.getResponses().containsKey("C"));
         }
         {
-            DataDelta dataDelta = new DataDelta(new TestDataB("World"));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("C"));
+            val dataDelta = new DataDelta(new TestDataB("World"));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("C"));
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("E"));
-            Assert.assertTrue(response.getResponses().containsKey("F"));
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("E"));
+            assertTrue(response.getResponses().containsKey("F"));
         }
     }
     @Test
     public void testOptionalComingFirst() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlow);
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlow);
         {
-            DataDelta dataDelta = new DataDelta(new TestDataB("World"));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertTrue(response.getResponses().isEmpty());
-            Assert.assertFalse(response.getResponses().containsKey("C"));
+            val dataDelta = new DataDelta(new TestDataB("World"));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertTrue(response.getResponses().isEmpty());
+            assertFalse(response.getResponses().containsKey("C"));
         }
         {
-            DataDelta dataDelta = new DataDelta(new TestDataA("Hello"));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("C"));
+            val dataDelta = new DataDelta(new TestDataA("Hello"));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("C"));
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("E"));
-            Assert.assertTrue(response.getResponses().containsKey("F"));
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("E"));
+            assertTrue(response.getResponses().containsKey("F"));
         }
     }
 

--- a/src/test/java/io/appform/databuilderframework/DataFlowWithTransientDataTest.java
+++ b/src/test/java/io/appform/databuilderframework/DataFlowWithTransientDataTest.java
@@ -1,69 +1,67 @@
 package io.appform.databuilderframework;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.appform.databuilderframework.engine.*;
-import io.appform.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
-import io.appform.databuilderframework.model.*;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import io.appform.databuilderframework.engine.*;
+import io.appform.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
+import io.appform.databuilderframework.model.*;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Assert;
+import lombok.val;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @Slf4j
 public class DataFlowWithTransientDataTest {
 
-    private DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
-    private DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
-    private ExecutionGraphGenerator executionGraphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
-    private DataFlow dataFlow = new DataFlow();
-    private DataFlow dataFlowError = new DataFlow();
+    private final DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager()
+            .register(ImmutableSet.of("A", "B"), "C", "BuilderA", TestBuilderA.class )
+            .register(ImmutableSet.of("C", "D"), "E", "BuilderB", TestBuilderB.class )
+            .register(ImmutableSet.of("A", "E"), "F", "BuilderC", TestBuilderC.class )
+            .register(ImmutableSet.of("X"), "Y", "BuilderX", TestBuilderError.class);
+    private final DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
+    private final ExecutionGraphGenerator executionGraphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
+    private final DataFlow dataFlow = new DataFlow()
+            .setTargetData("F")
+            .setTransients(Sets.newHashSet("C"));
 
     @Before
     public void setup() throws Exception {
-        dataBuilderMetadataManager
-                .register(ImmutableSet.of("A", "B"), "C", "BuilderA", TestBuilderA.class )
-                .register(ImmutableSet.of("C", "D"), "E", "BuilderB", TestBuilderB.class )
-                .register(ImmutableSet.of("A", "E"), "F", "BuilderC", TestBuilderC.class )
-                .register(ImmutableSet.of("X"), "Y", "BuilderX", TestBuilderError.class);
-        //dataBuilderMetadataManager.register(ImmutableSet.of("F"),      "G", "BuilderD", TestBuilderD.class );
-        //dataBuilderMetadataManager.register(ImmutableSet.of("E", "C"), "G", "BuilderE", TestBuilderE.class );
-
-        dataFlow.setTargetData("F");
         dataFlow.setExecutionGraph(executionGraphGenerator.generateGraph(dataFlow).deepCopy());
-        dataFlow.setTransients(Sets.newHashSet("C"));
         log.info("{}",new ObjectMapper().writeValueAsString(dataFlow));
     }
 
     @Test
     public void testTransient() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlow);
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlow);
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertTrue(response.getResponses().isEmpty());
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertTrue(response.getResponses().isEmpty());
         }
         Data dataC = null;
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataB("World")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("C"));
-            DataSetAccessor accessor = new DataSetAccessor(dataFlowInstance.getDataSet());
-            Assert.assertTrue(accessor.checkForData(ImmutableSet.of("A", "B")));
-            Assert.assertFalse(accessor.checkForData("C"));
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataB("World")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("C"));
+            val accessor = new DataSetAccessor(dataFlowInstance.getDataSet());
+            assertTrue(accessor.checkForData(ImmutableSet.of("A", "B")));
+            assertFalse(accessor.checkForData("C"));
             dataC = response.getResponses().get("C");
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.newArrayList(new TestDataD("this"), dataC));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("E"));
-            Assert.assertTrue(response.getResponses().containsKey("F"));
+            val dataDelta = new DataDelta(Lists.newArrayList(new TestDataD("this"), dataC));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("E"));
+            assertTrue(response.getResponses().containsKey("F"));
         }
     }
 }

--- a/src/test/java/io/appform/databuilderframework/DataSetAccessorTest.java
+++ b/src/test/java/io/appform/databuilderframework/DataSetAccessorTest.java
@@ -1,28 +1,27 @@
 package io.appform.databuilderframework;
 
-import io.appform.databuilderframework.engine.DataSetAccessor;
-import io.appform.databuilderframework.model.DataDelta;
-import io.appform.databuilderframework.model.DataSet;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import org.junit.Assert;
+import io.appform.databuilderframework.model.DataDelta;
+import io.appform.databuilderframework.model.DataSet;
+import lombok.val;
 import org.junit.Test;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class DataSetAccessorTest {
 
     @Test
     public void testGet() throws Exception {
-        DataSet dataSet = new DataSet();
-        DataSetAccessor dataSetAccessor = DataSet.accessor(dataSet);
+        val dataSet = new DataSet();
+        val dataSetAccessor = DataSet.accessor(dataSet);
         dataSetAccessor.merge(new TestDataA("RandomValue"));
-        TestDataA testDataA = dataSetAccessor.get("A", TestDataA.class);
-        Assert.assertEquals("RandomValue", testDataA.getValue());
-        Assert.assertNull(dataSetAccessor.get("X", TestDataA.class));
+        val testDataA = dataSetAccessor.get("A", TestDataA.class);
+        assertEquals("RandomValue", testDataA.getValue());
+        assertNull(dataSetAccessor.get("X", TestDataA.class));
 
         try {
-            TestDataB testDataB = dataSetAccessor.get("A", TestDataB.class);
+            dataSetAccessor.get("A", TestDataB.class);
         } catch (ClassCastException e) {
             return;
         }
@@ -31,29 +30,29 @@ public class DataSetAccessorTest {
 
     @Test
     public void testMerge() throws Exception {
-        DataSet dataSet = new DataSet();
-        DataSetAccessor dataSetAccessor = DataSet.accessor(dataSet);
-        DataDelta dataDelta = new DataDelta(Lists.newArrayList(new TestDataA("Hello"),
+        val dataSet = new DataSet();
+        val dataSetAccessor = DataSet.accessor(dataSet);
+        val dataDelta = new DataDelta(Lists.newArrayList(new TestDataA("Hello"),
                                                                 new TestDataB("World")));
         dataSetAccessor.merge(dataDelta);
-        TestDataA testDataA = dataSetAccessor.get("A", TestDataA.class);
-        Assert.assertEquals("Hello", testDataA.getValue());
-        TestDataB testDataB = dataSetAccessor.get("B", TestDataB.class);
-        Assert.assertEquals("World", testDataB.getValue());
+        val testDataA = dataSetAccessor.get("A", TestDataA.class);
+        assertEquals("Hello", testDataA.getValue());
+        val testDataB = dataSetAccessor.get("B", TestDataB.class);
+        assertEquals("World", testDataB.getValue());
     }
 
     @Test
     public void testCheckForData() throws Exception {
-        DataSet dataSet = new DataSet();
-        DataSetAccessor dataSetAccessor = DataSet.accessor(dataSet);
-        DataDelta dataDelta = new DataDelta(Lists.newArrayList(new TestDataA("Hello"),
+        val dataSet = new DataSet();
+        val dataSetAccessor = DataSet.accessor(dataSet);
+        val dataDelta = new DataDelta(Lists.newArrayList(new TestDataA("Hello"),
                 new TestDataB("World")));
         dataSetAccessor.merge(dataDelta);
-        Assert.assertTrue(dataSetAccessor.checkForData("A"));
-        Assert.assertFalse(dataSetAccessor.checkForData("X"));
-        Assert.assertTrue(dataSetAccessor.checkForData(ImmutableSet.of("A", "B")));
-        Assert.assertFalse(dataSetAccessor.checkForData(ImmutableSet.of("A", "X")));
-        Assert.assertFalse(dataSetAccessor.checkForData(ImmutableSet.of("X", "A")));
-        Assert.assertFalse(dataSetAccessor.checkForData(ImmutableSet.of("X", "Ys")));
+        assertTrue(dataSetAccessor.checkForData("A"));
+        assertFalse(dataSetAccessor.checkForData("X"));
+        assertTrue(dataSetAccessor.checkForData(ImmutableSet.of("A", "B")));
+        assertFalse(dataSetAccessor.checkForData(ImmutableSet.of("A", "X")));
+        assertFalse(dataSetAccessor.checkForData(ImmutableSet.of("X", "A")));
+        assertFalse(dataSetAccessor.checkForData(ImmutableSet.of("X", "Ys")));
     }
 }

--- a/src/test/java/io/appform/databuilderframework/InstantiatingDataBuilderFactoryTest.java
+++ b/src/test/java/io/appform/databuilderframework/InstantiatingDataBuilderFactoryTest.java
@@ -1,18 +1,15 @@
 package io.appform.databuilderframework;
 
+import com.google.common.collect.ImmutableSet;
 import io.appform.databuilderframework.engine.*;
 import io.appform.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
 import io.appform.databuilderframework.model.Data;
 import io.appform.databuilderframework.model.DataBuilderMeta;
-import io.appform.databuilderframework.model.ExecutionGraph;
-import com.google.common.collect.ImmutableSet;
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class InstantiatingDataBuilderFactoryTest {
     public static class WrongBuilder extends DataBuilder {
@@ -26,50 +23,45 @@ public class InstantiatingDataBuilderFactoryTest {
             return null;
         }
     }
-    private DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
-    private ExecutionGraphGenerator executionGraphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
-    private DataBuilderFactory dataBuilderFactory = new InstantiatingDataBuilderFactory(dataBuilderMetadataManager);
 
-    @Before
-    public void setup() throws Exception {
-        dataBuilderMetadataManager.register(ImmutableSet.of("A", "B"), "C", "BuilderA", TestBuilderA.class);
-        dataBuilderMetadataManager.register(ImmutableSet.of("A", "B"), "C", "BuilderB", null);
-        dataBuilderMetadataManager.register(ImmutableSet.of("A", "B"), "X", "BuilderC", WrongBuilder.class);
-    }
+    private final DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager()
+            .register(ImmutableSet.of("A", "B"), "C", "BuilderA", TestBuilderA.class)
+            .register(ImmutableSet.of("A", "B"), "C", "BuilderB", null)
+            .register(ImmutableSet.of("A", "B"), "X", "BuilderC", WrongBuilder.class);
 
+    private final DataBuilderFactory dataBuilderFactory = new InstantiatingDataBuilderFactory(dataBuilderMetadataManager);
 
     @Test
     public void testCreate() throws Exception {
         try {
-            Assert.assertNotNull(dataBuilderFactory.create(
+            assertNotNull(dataBuilderFactory.create(
                     DataBuilderMeta.builder()
                             .name("BuilderA")
                             .consumes(Collections.emptySet())
                             .build()));
             dataBuilderFactory.create(DataBuilderMeta.builder()
-                    .name("BuilderB")
-                    .consumes(Collections.emptySet())
-                    .build()); //Should throw
-        } catch (DataBuilderFrameworkException e) {
-            if(DataBuilderFrameworkException.ErrorCode.NO_BUILDER_FOUND_FOR_NAME == e.getErrorCode()) {
-                return;
-            }
+                                              .name("BuilderB")
+                                              .consumes(Collections.emptySet())
+                                              .build()); //Should throw
+        }
+        catch (DataBuilderFrameworkException e) {
+            assertEquals(DataBuilderFrameworkException.ErrorCode.NO_BUILDER_FOUND_FOR_NAME, e.getErrorCode());
+            return;
         }
         fail();
-     }
+    }
 
     @Test
     public void testFail() throws Exception {
-        ExecutionGraph executionGraph = new ExecutionGraph();
         try {
             dataBuilderFactory.create(DataBuilderMeta.builder()
-                    .name("BuilderC")
-                    .consumes(Collections.emptySet())
-                    .build()); //Should throw
-        } catch (DataBuilderFrameworkException e) {
-            if(DataBuilderFrameworkException.ErrorCode.INSTANTIATION_FAILURE == e.getErrorCode()) {
-                return;
-            }
+                                              .name("BuilderC")
+                                              .consumes(Collections.emptySet())
+                                              .build()); //Should throw
+        }
+        catch (DataBuilderFrameworkException e) {
+            assertEquals(DataBuilderFrameworkException.ErrorCode.INSTANTIATION_FAILURE, e.getErrorCode());
+            return;
         }
         fail();
     }

--- a/src/test/java/io/appform/databuilderframework/MultiThreadedDataFlowExecutorTest.java
+++ b/src/test/java/io/appform/databuilderframework/MultiThreadedDataFlowExecutorTest.java
@@ -1,130 +1,144 @@
 package io.appform.databuilderframework;
 
+import com.google.common.collect.Lists;
 import io.appform.databuilderframework.engine.*;
 import io.appform.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
 import io.appform.databuilderframework.model.*;
-import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Assert;
-import org.junit.Before;
+import lombok.val;
 import org.junit.Test;
 
 import java.util.Map;
 import java.util.concurrent.Executors;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 @Slf4j
 public class MultiThreadedDataFlowExecutorTest {
     private static class TestListener implements DataBuilderExecutionListener {
 
         @Override
-        public void beforeExecute(DataBuilderContext builderContext,
-        						  DataFlowInstance dataFlowInstance,
-                                  DataBuilderMeta builderToBeApplied,
-                                  DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
+        public void beforeExecute(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta, Map<String, Data> prevResponses) {
             log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
         }
 
         @Override
-        public void afterExecute(DataBuilderContext builderContext,
-        						 DataFlowInstance dataFlowInstance,
-                                 DataBuilderMeta builderToBeApplied,
-                                 DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
+        public void afterExecute(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) {
             log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
         }
 
         @Override
-        public void afterException(DataBuilderContext builderContext,
-        						   DataFlowInstance dataFlowInstance,
-                                   DataBuilderMeta builderToBeApplied,
-                                   DataDelta dataDelta,
-                                   Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
+        public void afterException(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta,
+                Map<String, Data> prevResponses, Throwable frameworkException) {
             log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
         }
 
     }
+
     private static class TestListenerBeforeExecutionError implements DataBuilderExecutionListener {
 
         @Override
-        public void preProcessing(DataFlowInstance dataFlowInstance,
-                                  DataDelta dataDelta) throws Exception {
-            System.out.println("Being called for: " + dataFlowInstance.getId());
+        public void preProcessing(
+                DataFlowInstance dataFlowInstance,
+                DataDelta dataDelta) {
+            log.info("Being called for: {}", dataFlowInstance.getId());
         }
 
         @Override
-        public void beforeExecute(DataBuilderContext builderContext,
-        						  DataFlowInstance dataFlowInstance,
-                                  DataBuilderMeta builderToBeApplied,
-                                  DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
+        public void beforeExecute(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
             //System.out.println(builderToBeApplied.getName() + " being called for: " + dataFlowInstance.getId());
             throw new Exception("Blah blah");
         }
 
         @Override
-        public void afterExecute(DataBuilderContext builderContext,
-        						 DataFlowInstance dataFlowInstance,
-                                 DataBuilderMeta builderToBeApplied,
-                                 DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
+        public void afterExecute(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) {
             log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
         }
 
         @Override
-        public void afterException(DataBuilderContext builderContext,
-        						   DataFlowInstance dataFlowInstance,
-                                   DataBuilderMeta builderToBeApplied,
-                                   DataDelta dataDelta,
-                                   Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
+        public void afterException(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta,
+                Map<String, Data> prevResponses, Throwable frameworkException) {
             log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
         }
 
         @Override
-        public void postProcessing(DataFlowInstance dataFlowInstance,
-                                   DataDelta dataDelta, DataExecutionResponse response,
-                                   Throwable frameworkException) throws Exception  {
+        public void postProcessing(
+                DataFlowInstance dataFlowInstance,
+                DataDelta dataDelta, DataExecutionResponse response,
+                Throwable frameworkException) {
             log.info("Being called for: {}", dataFlowInstance.getId());
         }
     }
+
     private static class TestListenerAfterExecutionError implements DataBuilderExecutionListener {
 
         @Override
-        public void preProcessing(DataFlowInstance dataFlowInstance,
-                                  DataDelta dataDelta) throws Exception {
+        public void preProcessing(
+                DataFlowInstance dataFlowInstance,
+                DataDelta dataDelta) {
             log.info("Being called for: {}", dataFlowInstance.getId());
         }
 
 
         @Override
-        public void beforeExecute(DataBuilderContext builderContext,
-        						  DataFlowInstance dataFlowInstance,
-                                  DataBuilderMeta builderToBeApplied,
-                                  DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
+        public void beforeExecute(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta, Map<String, Data> prevResponses) {
             log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
         }
 
         @Override
-        public void afterExecute(DataBuilderContext builderContext,
-        						 DataFlowInstance dataFlowInstance,
-                                 DataBuilderMeta builderToBeApplied,
-                                 DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
+        public void afterExecute(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
             //System.out.println(builderToBeApplied.getName() + " called for: " + dataFlowInstance.getId());
             throw new Exception("Blah blah");
 
         }
 
         @Override
-        public void afterException(DataBuilderContext builderContext,
-        						   DataFlowInstance dataFlowInstance,
-                                   DataBuilderMeta builderToBeApplied,
-                                   DataDelta dataDelta,
-                                   Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
+        public void afterException(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta,
+                Map<String, Data> prevResponses, Throwable frameworkException) {
             log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
         }
 
         @Override
-        public void postProcessing(DataFlowInstance dataFlowInstance,
-                                   DataDelta dataDelta, DataExecutionResponse response,
-                                   Throwable frameworkException) throws Exception  {
+        public void postProcessing(
+                DataFlowInstance dataFlowInstance,
+                DataDelta dataDelta, DataExecutionResponse response,
+                Throwable frameworkException) {
             log.info("Being called for: {}", dataFlowInstance.getId());
         }
     }
@@ -132,168 +146,154 @@ public class MultiThreadedDataFlowExecutorTest {
     private static class TestListenerAfterExceptionError implements DataBuilderExecutionListener {
 
         @Override
-        public void preProcessing(DataFlowInstance dataFlowInstance,
-                                  DataDelta dataDelta) throws Exception {
+        public void preProcessing(
+                DataFlowInstance dataFlowInstance,
+                DataDelta dataDelta) {
             System.out.println("Being called for: " + dataFlowInstance.getId());
         }
 
 
         @Override
-        public void beforeExecute(DataBuilderContext builderContext,
-        						  DataFlowInstance dataFlowInstance,
-                                  DataBuilderMeta builderToBeApplied,
-                                  DataDelta dataDelta, Map<String, Data> prevResponses) throws Exception {
+        public void beforeExecute(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta, Map<String, Data> prevResponses) {
             log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
         }
 
         @Override
-        public void afterExecute(DataBuilderContext builderContext,
-        						 DataFlowInstance dataFlowInstance,
-                                 DataBuilderMeta builderToBeApplied,
-                                 DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) throws Exception {
+        public void afterExecute(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta, Map<String, Data> prevResponses, Data currentResponse) {
             log.info("{} called for: {}", builderToBeApplied.getName(), dataFlowInstance.getId());
 
         }
 
         @Override
-        public void afterException(DataBuilderContext builderContext,
-        						   DataFlowInstance dataFlowInstance,
-                                   DataBuilderMeta builderToBeApplied,
-                                   DataDelta dataDelta,
-                                   Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
+        public void afterException(
+                DataBuilderContext builderContext,
+                DataFlowInstance dataFlowInstance,
+                DataBuilderMeta builderToBeApplied,
+                DataDelta dataDelta,
+                Map<String, Data> prevResponses, Throwable frameworkException) throws Exception {
             //System.out.println(builderToBeApplied.getName() + " called for: " + dataFlowInstance.getId());
             throw new Exception("Blah blah");
         }
 
         @Override
-        public void postProcessing(DataFlowInstance dataFlowInstance,
-                                   DataDelta dataDelta, DataExecutionResponse response,
-                                   Throwable frameworkException) throws Exception  {
+        public void postProcessing(
+                DataFlowInstance dataFlowInstance,
+                DataDelta dataDelta, DataExecutionResponse response,
+                Throwable frameworkException) {
             log.info("Being called for: {}", dataFlowInstance.getId());
         }
     }
 
-    private DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
-    private DataFlowExecutor executor = new MultiThreadedDataFlowExecutor(
-                                                new InstantiatingDataBuilderFactory(dataBuilderMetadataManager),
-                                                Executors.newFixedThreadPool(2));
-    private ExecutionGraphGenerator executionGraphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
-    private DataFlow dataFlow = new DataFlow();
-    private DataFlow dataFlowError = new DataFlow();
-    private DataFlow dataFlowValidationError = new DataFlow();
-    private DataFlow dataFlowValidationErrorWithPartialData = new DataFlow();
-
-    @Before
-    public void setup() throws Exception {
-        dataFlow = new DataFlowBuilder()
-                .withAnnotatedDataBuilder(TestBuilderA.class)
-                .withAnnotatedDataBuilder(TestBuilderB.class)
-                .withAnnotatedDataBuilder(TestBuilderC.class)
-                .withTargetData("F")
-                .build();
-
-        dataFlowError = new DataFlowBuilder()
-                .withAnnotatedDataBuilder(TestBuilderError.class)
-                .withTargetData("Y")
-                .build();
-        executor.registerExecutionListener(new TestListener());
-        executor.registerExecutionListener(new TestListenerBeforeExecutionError());
-        executor.registerExecutionListener(new TestListenerAfterExecutionError());
-        executor.registerExecutionListener(new TestListenerAfterExceptionError());
-
-        dataFlowValidationError = new DataFlowBuilder()
-                .withAnnotatedDataBuilder(TestBuilderDataValidationError.class)
-                .withTargetData("Y")
-                .build();
-        executor.registerExecutionListener(new TestListener());
-        executor.registerExecutionListener(new TestListenerBeforeExecutionError());
-        executor.registerExecutionListener(new TestListenerAfterExecutionError());
-        executor.registerExecutionListener(new TestListenerAfterExceptionError());
-
-        dataFlowValidationErrorWithPartialData = new DataFlowBuilder()
-                .withAnnotatedDataBuilder(TestBuilderA.class)
-                .withAnnotatedDataBuilder(TestBuilderDataValidationError.class)
-                .withTargetData("Y")
-                .build();
-        executor.registerExecutionListener(new TestListener());
-        executor.registerExecutionListener(new TestListenerBeforeExecutionError());
-        executor.registerExecutionListener(new TestListenerAfterExecutionError());
-        executor.registerExecutionListener(new TestListenerAfterExceptionError());
-
-    }
+    private final DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
+    private final DataFlowExecutor executor = new MultiThreadedDataFlowExecutor(
+            new InstantiatingDataBuilderFactory(dataBuilderMetadataManager),
+            Executors.newFixedThreadPool(2))
+            .registerExecutionListener(new TestListener())
+            .registerExecutionListener(new TestListenerBeforeExecutionError())
+            .registerExecutionListener(new TestListenerAfterExecutionError())
+            .registerExecutionListener(new TestListenerAfterExceptionError());
+    private final DataFlow dataFlow = new DataFlowBuilder()
+            .withAnnotatedDataBuilder(TestBuilderA.class)
+            .withAnnotatedDataBuilder(TestBuilderB.class)
+            .withAnnotatedDataBuilder(TestBuilderC.class)
+            .withTargetData("F")
+            .build();
+    private final DataFlow dataFlowError = new DataFlowBuilder()
+            .withAnnotatedDataBuilder(TestBuilderError.class)
+            .withTargetData("Y")
+            .build();
+    private final DataFlow dataFlowValidationError = new DataFlowBuilder()
+            .withAnnotatedDataBuilder(TestBuilderDataValidationError.class)
+            .withTargetData("Y")
+            .build();
+    private final DataFlow dataFlowValidationErrorWithPartialData = new DataFlowBuilder()
+            .withAnnotatedDataBuilder(TestBuilderA.class)
+            .withAnnotatedDataBuilder(TestBuilderDataValidationError.class)
+            .withTargetData("Y")
+            .build();
 
     @Test
     public void testRunThreeSteps() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlow);
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlow);
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertTrue(response.getResponses().isEmpty());
+            val dataDelta = new DataDelta(Lists.newArrayList(new TestDataA("Hello")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertTrue(response.getResponses().isEmpty());
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataB("World")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("C"));
+            val dataDelta = new DataDelta(Lists.newArrayList(new TestDataB("World")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("C"));
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("E"));
-            Assert.assertTrue(response.getResponses().containsKey("F"));
+            val dataDelta = new DataDelta(Lists.newArrayList(new TestDataD("this")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("E"));
+            assertTrue(response.getResponses().containsKey("F"));
         }
     }
 
     @Test
     public void testRunTwoSteps() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlow);
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlow);
         {
-            DataDelta dataDelta = new DataDelta(Lists.newArrayList(new TestDataA("Hello"), new TestDataB("World")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("C"));
+            val dataDelta = new DataDelta(Lists.newArrayList(new TestDataA("Hello"), new TestDataB("World")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("C"));
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataD("this")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertFalse(response.getResponses().isEmpty());
-            Assert.assertTrue(response.getResponses().containsKey("E"));
-            Assert.assertTrue(response.getResponses().containsKey("F"));
+            val dataDelta = new DataDelta(Lists.newArrayList(new TestDataD("this")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertFalse(response.getResponses().isEmpty());
+            assertTrue(response.getResponses().containsKey("E"));
+            assertTrue(response.getResponses().containsKey("F"));
         }
     }
+
     @Test
     public void testRunSingleStep() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlow);
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlow);
         {
-            DataDelta dataDelta = new DataDelta(Lists.newArrayList(
-                                            new TestDataA("Hello"), new TestDataB("World"),
-                                            new TestDataD("this"), new TestDataG("Hmmm")));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            Assert.assertEquals(3, response.getResponses().size());
-            Assert.assertTrue(response.getResponses().containsKey("C"));
-            Assert.assertTrue(response.getResponses().containsKey("E"));
-            Assert.assertTrue(response.getResponses().containsKey("F"));
+            val dataDelta = new DataDelta(Lists.newArrayList(
+                    new TestDataA("Hello"), new TestDataB("World"),
+                    new TestDataD("this"), new TestDataG("Hmmm")));
+            val response = executor.run(dataFlowInstance, dataDelta);
+            assertEquals(3, response.getResponses().size());
+            assertTrue(response.getResponses().containsKey("C"));
+            assertTrue(response.getResponses().containsKey("E"));
+            assertTrue(response.getResponses().containsKey("F"));
         }
     }
 
     @Test
-    public void testRunError() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlowError);
+    public void testRunError() {
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlowError);
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataX("Hello")));
+            val dataDelta = new DataDelta(Lists.newArrayList(new TestDataX("Hello")));
             try {
                 executor.run(dataFlowInstance, dataDelta);
-            } catch (Exception e) {
-                Assert.assertEquals("TestError", e.getCause().getMessage());
+            }
+            catch (Exception e) {
+                assertEquals("TestError", e.getCause().getMessage());
                 return;
             }
             fail("Should have thrown exception");
@@ -301,15 +301,16 @@ public class MultiThreadedDataFlowExecutorTest {
     }
 
     @Test
-    public void testRunErrorNPE() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlowError);
+    public void testRunErrorNPE() {
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlowError);
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataX("Hello"), null));
+            val dataDelta = new DataDelta(Lists.newArrayList(new TestDataX("Hello"), null));
             try {
                 executor.run(dataFlowInstance, dataDelta);
-            } catch (Exception e) {
+            }
+            catch (Exception e) {
                 return;
             }
             fail("Should have thrown exception");
@@ -317,16 +318,17 @@ public class MultiThreadedDataFlowExecutorTest {
     }
 
     @Test
-    public void testRunValidationError() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlowValidationError);
+    public void testRunValidationError() {
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlowValidationError);
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataC("Hello")));
+            val dataDelta = new DataDelta(Lists.newArrayList(new TestDataC("Hello")));
             try {
                 executor.run(dataFlowInstance, dataDelta);
-            } catch (Exception e) {
-                Assert.assertEquals("DataValidationError", e.getCause().getMessage());
+            }
+            catch (Exception e) {
+                assertEquals("DataValidationError", e.getCause().getMessage());
                 return;
             }
             fail("Should have thrown exception");
@@ -334,18 +336,19 @@ public class MultiThreadedDataFlowExecutorTest {
     }
 
     @Test
-    public void testRunValidationErrorWithPartialData() throws Exception {
-        DataFlowInstance dataFlowInstance = new DataFlowInstance();
-        DataExecutionResponse response = new DataExecutionResponse();
-        dataFlowInstance.setId("testflow");
-        dataFlowInstance.setDataFlow(dataFlowValidationErrorWithPartialData);
+    public void testRunValidationErrorWithPartialData() {
+        val dataFlowInstance = new DataFlowInstance()
+                .setId("testflow")
+                .setDataFlow(dataFlowValidationErrorWithPartialData);
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("Hello"), new TestDataB("World")));
+            val dataDelta = new DataDelta(Lists.newArrayList(new TestDataA("Hello"),
+                                                                   new TestDataB("World")));
             try {
-                response = executor.run(dataFlowInstance, dataDelta);
-            } catch (DataValidationException e) {
-                DataExecutionResponse dataExecutionResponse = e.getResponse();
-                Assert.assertTrue(dataExecutionResponse.getResponses().containsKey("C"));
+                executor.run(dataFlowInstance, dataDelta);
+            }
+            catch (DataValidationException e) {
+                val dataExecutionResponse = e.getResponse();
+                assertTrue(dataExecutionResponse.getResponses().containsKey("C"));
                 return;
             }
             fail("Should have thrown exception");

--- a/src/test/java/io/appform/databuilderframework/PerfWithAccessesTest.java
+++ b/src/test/java/io/appform/databuilderframework/PerfWithAccessesTest.java
@@ -1,76 +1,50 @@
 package io.appform.databuilderframework;
 
+import com.google.common.collect.Lists;
 import io.appform.databuilderframework.engine.*;
 import io.appform.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
 import io.appform.databuilderframework.model.*;
-import com.google.common.collect.Lists;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
-/**
- * Created with IntelliJ IDEA.
- * User: vinay.varma
- * Date: 5/18/15
- * Time: 11:42 PM
- * To change this template use File | Settings | File Templates.
- */
+@Slf4j
 public class PerfWithAccessesTest {
-    private DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
-    private DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
-    private DataFlow dataFlow = new DataFlow();
-    private DataFlow dataFlowWithAccesses = new DataFlow();
-
-    @Before
-    public void setup() throws Exception {
-        dataFlow = new DataFlowBuilder()
-                .withAnnotatedDataBuilder(TestBuilderWithoutAccesses.class)
-                .withTargetData("X")
-                .build();
-        dataFlowWithAccesses = new DataFlowBuilder()
-                .withAnnotatedDataBuilder(TestBuilderAccesses.class)
-                .withTargetData("X")
-                .build();
-    }
+    private final DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
+    private final DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
+    private final DataFlow dataFlow = new DataFlowBuilder()
+            .withAnnotatedDataBuilder(TestBuilderWithoutAccesses.class)
+            .withTargetData("X")
+            .build();
+    private final DataFlow dataFlowWithAccesses = new DataFlowBuilder()
+            .withAnnotatedDataBuilder(TestBuilderAccesses.class)
+            .withTargetData("X")
+            .build();
 
     @Test
     public void shouldBeComparableWithoutAnyAccesibleData() throws DataBuilderFrameworkException, DataValidationException {
-        long simpleTime = 0;
-        for (int i = 0; i < 10000; i++) {
-            DataFlowInstance dataFlowInstance = new DataFlowInstance();
-            dataFlowInstance.setId("testflow");
-            dataFlowInstance.setDataFlow(dataFlow);
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("HEy")));
-            long startTime = System.currentTimeMillis();
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            simpleTime += (System.currentTimeMillis() - startTime);
-            Assert.assertEquals(1, response.getResponses().size());
-        }
-        long accessTime = 0;
-        for (int i = 0; i < 10000; i++) {
-            DataFlowInstance dataFlowInstance = new DataFlowInstance();
-            dataFlowInstance.setId("testflow");
-            dataFlowInstance.setDataFlow(dataFlowWithAccesses);
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("HEy"), new TestDataD("DD")));
-            long startTime = System.currentTimeMillis();
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            accessTime += (System.currentTimeMillis() - startTime);
-            Assert.assertEquals(1, response.getResponses().size());
-        }
-        long simpleAccessTime = 0;
-        for (int i = 0; i < 10000; i++) {
-            DataFlowInstance dataFlowInstance = new DataFlowInstance();
-            dataFlowInstance.setId("testflow");
-            dataFlowInstance.setDataFlow(dataFlowWithAccesses);
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("HEy")));
-            long startTime = System.currentTimeMillis();
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
-            simpleAccessTime += (System.currentTimeMillis() - startTime);
-            Assert.assertEquals(1, response.getResponses().size());
-        }
+        val simpleTime = executeFlow(dataFlow);
+        val accessTime = executeFlow(dataFlowWithAccesses);
+        val simpleAccessTime = executeFlow(dataFlowWithAccesses);
 
-        System.out.println(String.format("Time without Accesses :%d Time with Accesses :%d Time with accesses w/o data :%d "
-                , simpleTime, accessTime, simpleAccessTime));
+        log.info("Time without Accesses : {} ms Time with Accesses : {} ms Time with accesses w/o data : {} ms ",
+                 simpleTime, accessTime, simpleAccessTime);
+    }
+
+    private long executeFlow(final DataFlow dataFlow) throws DataValidationException {
+        long executionTime =  0L;
+        for (int i = 0; i < 10000; i++) {
+            val dataFlowInstance = new DataFlowInstance()
+                    .setId("testflow")
+                    .setDataFlow(dataFlow);
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(new TestDataA("HEy")));
+            val startTime = System.currentTimeMillis();
+            val response = executor.run(dataFlowInstance, dataDelta);
+            executionTime += (System.currentTimeMillis() - startTime);
+            Assert.assertEquals(1, response.getResponses().size());
+        }
+        return executionTime;
     }
 
 

--- a/src/test/java/io/appform/databuilderframework/TestBuilderA.java
+++ b/src/test/java/io/appform/databuilderframework/TestBuilderA.java
@@ -3,18 +3,17 @@ package io.appform.databuilderframework;
 import io.appform.databuilderframework.annotations.DataBuilderInfo;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.model.Data;
-import io.appform.databuilderframework.model.DataSet;
+import lombok.val;
 
 @DataBuilderInfo(name = "BuilderA", consumes = {"B", "A"}, produces = "C")
 public class TestBuilderA extends DataBuilder {
 
     @Override
     public Data process(DataBuilderContext context) {
-        DataSetAccessor dataSetAccessor = context.getDataSet().accessor();
-        TestDataA a = dataSetAccessor.get("A", TestDataA.class);
-        TestDataB b = dataSetAccessor.get("B", TestDataB.class);
+        val dataSetAccessor = context.getDataSet().accessor();
+        val a = dataSetAccessor.get("A", TestDataA.class);
+        val b = dataSetAccessor.get("B", TestDataB.class);
         return new TestDataC(a.getValue() + " " + b.getValue());
     }
 }

--- a/src/test/java/io/appform/databuilderframework/TestContextGetSet.java
+++ b/src/test/java/io/appform/databuilderframework/TestContextGetSet.java
@@ -1,5 +1,6 @@
 package io.appform.databuilderframework;
 
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import org.junit.Assert;
 import org.junit.Test;
@@ -72,8 +73,9 @@ public class TestContextGetSet {
     public void testNullKey() {
         try {
             new DataBuilderContext().saveContextData(null, new TestClass("XX", 1));
-        } catch (RuntimeException e) {
-            Assert.assertEquals("Invalid key for context data. Key cannot be null/empty", e.getMessage());
+        } catch (UncheckedExecutionException e) {
+            Assert.assertEquals(IllegalArgumentException.class, e.getCause().getClass());
+            Assert.assertEquals("java.lang.IllegalArgumentException: Invalid key for context data. Key cannot be null/empty", e.getMessage());
             return;
         }
         fail("Expected exception was not raised");

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/ContextSwitchOverHeadTest.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/ContextSwitchOverHeadTest.java
@@ -1,204 +1,182 @@
 package io.appform.databuilderframework.cmplxscenariotest;
 
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderA1;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderA2;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderA3;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderB1;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderB2;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderB3;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderB4;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderB5;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderC;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderD;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderE1;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderE2;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderE3;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderE4;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderE5;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderE6;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderF;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderG;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderH;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderI;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderJ;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderK;
+import com.google.common.collect.Sets;
+import io.appform.databuilderframework.cmplxscenariotest.builders.*;
 import io.appform.databuilderframework.cmplxscenariotest.data.DataA;
-import io.appform.databuilderframework.cmplxscenariotest.data.DataI;
 import io.appform.databuilderframework.cmplxscenariotest.data.InputAData;
 import io.appform.databuilderframework.engine.*;
 import io.appform.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
-import io.appform.databuilderframework.model.*;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-
+import io.appform.databuilderframework.model.DataExecutionResponse;
+import io.appform.databuilderframework.model.DataFlow;
+import io.appform.databuilderframework.model.DataFlowInstance;
+import io.appform.databuilderframework.model.ExecutionGraph;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Assert;
+import lombok.val;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertFalse;
+
 @Slf4j
+@Ignore
 public class ContextSwitchOverHeadTest {
-	private final DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
-	private  DataFlow dataflow = new DataFlow();
-	
-	@Before
-	public void setup() throws Exception {
-		dataBuilderMetadataManager.register(BuilderA1.class);
-		dataBuilderMetadataManager.register(BuilderA2.class);
-		dataBuilderMetadataManager.register(BuilderA3.class);
-		dataBuilderMetadataManager.register(BuilderB1.class);
-		dataBuilderMetadataManager.register(BuilderB2.class);
-		dataBuilderMetadataManager.register(BuilderB3.class);
-		dataBuilderMetadataManager.register(BuilderB4.class);
-		dataBuilderMetadataManager.register(BuilderB5.class);
-		dataBuilderMetadataManager.register(BuilderC.class);
-		dataBuilderMetadataManager.register(BuilderD.class);
-		dataBuilderMetadataManager.register(BuilderE1.class);
-		dataBuilderMetadataManager.register(BuilderE2.class);
-		dataBuilderMetadataManager.register(BuilderE3.class);
-		dataBuilderMetadataManager.register(BuilderE4.class);
-		dataBuilderMetadataManager.register(BuilderE5.class);
-		dataBuilderMetadataManager.register(BuilderE6.class);
-		dataBuilderMetadataManager.register(BuilderF.class);
-		dataBuilderMetadataManager.register(BuilderG.class);
-		dataBuilderMetadataManager.register(BuilderH.class);
-		dataBuilderMetadataManager.register(BuilderI.class);
-		dataBuilderMetadataManager.register(BuilderJ.class);
-		dataBuilderMetadataManager.register(BuilderK.class);
+    private final DataBuilderMetadataManager dataBuilderMetadataManager
+            = new DataBuilderMetadataManager()
+            .register(BuilderA1.class)
+            .register(BuilderA2.class)
+            .register(BuilderA3.class)
+            .register(BuilderB1.class)
+            .register(BuilderB2.class)
+            .register(BuilderB3.class)
+            .register(BuilderB4.class)
+            .register(BuilderB5.class)
+            .register(BuilderC.class)
+            .register(BuilderD.class)
+            .register(BuilderE1.class)
+            .register(BuilderE2.class)
+            .register(BuilderE3.class)
+            .register(BuilderE4.class)
+            .register(BuilderE5.class)
+            .register(BuilderE6.class)
+            .register(BuilderF.class)
+            .register(BuilderG.class)
+            .register(BuilderH.class)
+            .register(BuilderI.class)
+            .register(BuilderJ.class)
+            .register(BuilderK.class);
 
-		dataflow.setDescription("Complex DataFlow");
-		dataflow.setEnabled(true);
-		dataflow.setTargetData("K");
-		dataflow.setTransients(Sets.newHashSet("IA","I"));
-		dataflow.setName("complext_flow");
+    private final DataFlow dataflow = new DataFlow()
+            .setDescription("Complex DataFlow")
+            .setEnabled(true)
+            .setTargetData("K")
+            .setTransients(Sets.newHashSet("IA", "I"))
+            .setName("complext_flow");
 
-		ExecutionGraphGenerator graphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
-		ExecutionGraph graph = graphGenerator.generateGraph(dataflow);
-		dataflow.setExecutionGraph(graph);
-	}
+    @Before
+    public void setup() throws Exception {
+        ExecutionGraphGenerator graphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
+        ExecutionGraph graph = graphGenerator.generateGraph(dataflow);
+        dataflow.setExecutionGraph(graph);
+    }
 
-	@Test
-	public void testWhenConccurencyIsLessThanBuilderSize() throws Exception{
-		runTestWithUnBoundedQueue(150, 100);
-	}
-	
-	@Test
-	public void testWhenConccurencyIsMoreThanBuilderSize() throws Exception{
-		log.info("testWhenConccurencyIsMoreThanBuilderSize");
-		runTestWithUnBoundedQueue(50, 150);
-	}
-	
-	@Test
-	public void testWhenConccurencyIsSameAsBuilderSize() throws Exception{
-		log.info("testWhenConccurencyIsSameAsBuilderSize");
-		runTestWithUnBoundedQueue(150, 150);
-	}
-	
-	public void runTestWithUnBoundedQueue(int builderThreadSize, int concurrentRequestSize) throws Exception{
+    @Test
+    public void testWhenConccurencyIsLessThanBuilderSize() throws Exception {
+        runTestWithUnBoundedQueue(150, 100);
+    }
 
-		log.info("running unbounded queue test with builder size {} and concurrecy {}",builderThreadSize,concurrentRequestSize);
-		final SimpleDataFlowExecutor se = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
-		final ProfileExecutor builderExecutor = new ProfileExecutor(builderThreadSize, -1, 50);
-		final MultiThreadedDataFlowExecutor me =  new MultiThreadedDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager),builderExecutor);;
-		final OptimizedMultiThreadedDataFlowExecutor ome =  new OptimizedMultiThreadedDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager),builderExecutor);;
-		final DataFlow dataflowRef = dataflow;
-		
-		ExecutorService exec = Executors.newFixedThreadPool(concurrentRequestSize); // concurrent users
-		long start = System.currentTimeMillis();
-		for(int i=0; i<1000; i++){
-			exec.execute(new Runnable() {
+    @Test
+    public void testWhenConccurencyIsMoreThanBuilderSize() throws Exception {
+        log.info("testWhenConccurencyIsMoreThanBuilderSize");
+        runTestWithUnBoundedQueue(50, 150);
+    }
 
-				@Override
-				public void run() {
-					try {
-						final DataFlowInstance instance  = new DataFlowInstance("test", dataflowRef);
-						DataExecutionResponse resp = se.run(instance, new DataA(), new InputAData());
-						Assert.assertEquals(true,resp.getResponses().containsKey("K"));
-					} catch (DataBuilderFrameworkException e) {
-						// TODO Auto-generated catch block
-						e.printStackTrace();
-					} catch (DataValidationException e) {
-						// TODO Auto-generated catch block
-						e.printStackTrace();
-					}
-				}
-			});
-		}
-		exec.shutdown();
-		exec.awaitTermination(200, TimeUnit.SECONDS);
-		log.info("se {}", (System.currentTimeMillis() - start));
+    @Test
+    public void testWhenConccurencyIsSameAsBuilderSize() throws Exception {
+        log.info("testWhenConccurencyIsSameAsBuilderSize");
+        runTestWithUnBoundedQueue(150, 150);
+    }
 
+    public void runTestWithUnBoundedQueue(int builderThreadSize, int concurrentRequestSize) throws Exception {
 
+        log.info("running unbounded queue test with builder size {} and concurrecy {}",
+                 builderThreadSize,
+                 concurrentRequestSize);
+        val se = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(
+                dataBuilderMetadataManager));
+        val builderExecutor = new ProfileExecutor(builderThreadSize, -1, 50);
+        val me = new MultiThreadedDataFlowExecutor(new InstantiatingDataBuilderFactory(
+                dataBuilderMetadataManager), builderExecutor);
 
-		ExecutorService newExec = Executors.newFixedThreadPool(concurrentRequestSize); // concurrent users
-		start = System.currentTimeMillis();
-		for(int i=0; i<1000; i++){
-			newExec.execute(new Runnable() {
+        val ome = new OptimizedMultiThreadedDataFlowExecutor(new InstantiatingDataBuilderFactory(
+                dataBuilderMetadataManager), builderExecutor);
 
-				@Override
-				public void run() {
-					try {
-						final DataFlowInstance instance  = new DataFlowInstance("test", dataflowRef);
-						DataExecutionResponse resp = me.run(instance, new DataA(), new InputAData());
-						Assert.assertEquals(true,resp.getResponses().containsKey("K"));
-						//						System.out.println(resp.getResponses().keySet());
-						//						System.out.println(iRef);
-					} catch (DataBuilderFrameworkException e) {
-						// TODO Auto-generated catch block
-						e.printStackTrace();
-					} catch (DataValidationException e) {
-						// TODO Auto-generated catch block
-						e.printStackTrace();
-					}
-				}
-			});
-		}
-		newExec.shutdown();
-		newExec.awaitTermination(200, TimeUnit.SECONDS);
-		log.info("me {}", (System.currentTimeMillis() - start));
-		log.info("me run: context switches over threshold count {}, max latent switch: {}, rejections {}",
-				builderExecutor.getNumberOfContextSwitchesOverThresHold(), builderExecutor.getMaxContextSwitchLatency(),
-				builderExecutor.getRejectedCount());
-		builderExecutor.resetStats();
+        val dataflowRef = dataflow;
 
+        val exec = Executors.newFixedThreadPool(concurrentRequestSize); // concurrent users
+        long start = System.currentTimeMillis();
+        val failed = new AtomicBoolean();
+        for (int i = 0; i < 1000; i++) {
+            exec.execute(() -> {
+                try {
+                    val instance = new DataFlowInstance("test", dataflowRef);
+                    val resp = se.run(instance, new DataA(), new InputAData());
+                    failed.set(resp.getResponses().containsKey("K"));
+                }
+                catch (DataBuilderFrameworkException | DataValidationException e) {
+                    log.error("Error during execution", e);
+                    failed.set(true);
+                }
+            });
+        }
+        exec.shutdown();
+        exec.awaitTermination(200, TimeUnit.SECONDS);
+        log.info("se {}", (System.currentTimeMillis() - start));
+        assertFalse(failed.get());
 
-		ExecutorService omeExec = Executors.newFixedThreadPool(concurrentRequestSize); // concurrent users
-		start = System.currentTimeMillis();
-		for(int i=0; i<1000; i++){
-			omeExec.execute(new Runnable() {
+        val newExec = Executors.newFixedThreadPool(concurrentRequestSize); // concurrent users
+        start = System.currentTimeMillis();
+        for (int i = 0; i < 1000; i++) {
+            newExec.execute(new Runnable() {
 
-				@Override
-				public void run() {
-					try {
-						final DataFlowInstance instance  = new DataFlowInstance("test", dataflowRef);
-						DataExecutionResponse resp = ome.run(instance, new DataA(), new InputAData());
-						Assert.assertEquals(true,resp.getResponses().containsKey("K"));
-					} catch (DataBuilderFrameworkException e) {
-						// TODO Auto-generated catch block
-						e.printStackTrace();
-					} catch (DataValidationException e) {
-						// TODO Auto-generated catch block
-						e.printStackTrace();
-					}
-				}
-			});
-		}
-		omeExec.shutdown();
-		omeExec.awaitTermination(200, TimeUnit.SECONDS);
-		log.info("ome {}"+(System.currentTimeMillis() - start));
-		log.info("ome run: context switches over threshold count {}, max latent switch: {}, rejections {}",
-				builderExecutor.getNumberOfContextSwitchesOverThresHold(), builderExecutor.getMaxContextSwitchLatency(),
-				builderExecutor.getRejectedCount());
-		builderExecutor.resetStats();
-		builderExecutor.shutdownNow();
-	}
+                @Override
+                public void run() {
+                    try {
+                        final DataFlowInstance instance = new DataFlowInstance("test", dataflowRef);
+                        DataExecutionResponse resp = me.run(instance, new DataA(), new InputAData());
+                        failed.set(resp.getResponses().containsKey("K"));
+
+                    }
+                    catch (DataBuilderFrameworkException | DataValidationException e) {
+                        log.error("Error during execution", e);
+                        failed.set(true);
+                    }
+                }
+            });
+        }
+        newExec.shutdown();
+        newExec.awaitTermination(200, TimeUnit.SECONDS);
+        log.info("me {}", (System.currentTimeMillis() - start));
+        log.info("me run: context switches over threshold count {}, max latent switch: {}, rejections {}",
+                 builderExecutor.getNumberOfContextSwitchesOverThresHold(),
+                 builderExecutor.getMaxContextSwitchLatency(),
+                 builderExecutor.getRejectedCount());
+        builderExecutor.resetStats();
+        assertFalse(failed.get());
+
+        val omeExec = Executors.newFixedThreadPool(concurrentRequestSize); // concurrent users
+        start = System.currentTimeMillis();
+        for (int i = 0; i < 1000; i++) {
+            omeExec.execute(new Runnable() {
+
+                @Override
+                public void run() {
+                    try {
+                        final DataFlowInstance instance = new DataFlowInstance("test", dataflowRef);
+                        DataExecutionResponse resp = ome.run(instance, new DataA(), new InputAData());
+                        failed.set(resp.getResponses().containsKey("K"));
+                    }
+                    catch (DataBuilderFrameworkException | DataValidationException e) {
+                        log.error("Error during execution", e);
+                        failed.set(true);
+                    }
+                }
+            });
+        }
+        omeExec.shutdown();
+        omeExec.awaitTermination(200, TimeUnit.SECONDS);
+        log.info("ome {}" + (System.currentTimeMillis() - start));
+        log.info("ome run: context switches over threshold count {}, max latent switch: {}, rejections {}",
+                 builderExecutor.getNumberOfContextSwitchesOverThresHold(),
+                 builderExecutor.getMaxContextSwitchLatency(),
+                 builderExecutor.getRejectedCount());
+        builderExecutor.resetStats();
+        builderExecutor.shutdownNow();
+        assertFalse(failed.get());
+    }
 
 }

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/ExecutionGraphGeneratorTest.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/ExecutionGraphGeneratorTest.java
@@ -2,89 +2,100 @@ package io.appform.databuilderframework.cmplxscenariotest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderA1;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderA2;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderA3;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderB1;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderB2;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderB3;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderB4;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderB5;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderC;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderD;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderE1;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderE2;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderE3;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderE4;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderE5;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderE6;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderF;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderG;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderH;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderI;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderJ;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderK;
-import io.appform.databuilderframework.cmplxscenariotest.data.DataI;
-import io.appform.databuilderframework.cmplxscenariotest.data.InputAData;
-import io.appform.databuilderframework.engine.*;
-import io.appform.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
-import io.appform.databuilderframework.model.*;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-
+import io.appform.databuilderframework.cmplxscenariotest.builders.*;
+import io.appform.databuilderframework.engine.DataBuilderMetadataManager;
+import io.appform.databuilderframework.engine.ExecutionGraphGenerator;
+import io.appform.databuilderframework.model.DataBuilderMeta;
+import io.appform.databuilderframework.model.DataFlow;
+import io.appform.databuilderframework.model.ExecutionGraph;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Assert;
-import org.junit.Before;
+import lombok.val;
 import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
 
 @Slf4j
 public class ExecutionGraphGeneratorTest {
-    private DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
-
-
-    @Before
-    public void setup() throws Exception {
-        dataBuilderMetadataManager.register(BuilderA1.class);
-        dataBuilderMetadataManager.register(BuilderA2.class);
-        dataBuilderMetadataManager.register(BuilderA3.class);
-        dataBuilderMetadataManager.register(BuilderB1.class);
-        dataBuilderMetadataManager.register(BuilderB2.class);
-        dataBuilderMetadataManager.register(BuilderB3.class);
-        dataBuilderMetadataManager.register(BuilderB4.class);
-        dataBuilderMetadataManager.register(BuilderB5.class);
-        dataBuilderMetadataManager.register(BuilderC.class);
-        dataBuilderMetadataManager.register(BuilderD.class);
-        dataBuilderMetadataManager.register(BuilderE1.class);
-        dataBuilderMetadataManager.register(BuilderE2.class);
-        dataBuilderMetadataManager.register(BuilderE3.class);
-        dataBuilderMetadataManager.register(BuilderE4.class);
-        dataBuilderMetadataManager.register(BuilderE5.class);
-        dataBuilderMetadataManager.register(BuilderE6.class);
-        dataBuilderMetadataManager.register(BuilderF.class);
-        dataBuilderMetadataManager.register(BuilderG.class);
-        dataBuilderMetadataManager.register(BuilderH.class);
-        dataBuilderMetadataManager.register(BuilderI.class);
-        dataBuilderMetadataManager.register(BuilderJ.class);
-        dataBuilderMetadataManager.register(BuilderK.class);
-    }
+    private final DataBuilderMetadataManager dataBuilderMetadataManager
+            = new DataBuilderMetadataManager()
+            .register(BuilderA1.class)
+            .register(BuilderA2.class)
+            .register(BuilderA3.class)
+            .register(BuilderB1.class)
+            .register(BuilderB2.class)
+            .register(BuilderB3.class)
+            .register(BuilderB4.class)
+            .register(BuilderB5.class)
+            .register(BuilderC.class)
+            .register(BuilderD.class)
+            .register(BuilderE1.class)
+            .register(BuilderE2.class)
+            .register(BuilderE3.class)
+            .register(BuilderE4.class)
+            .register(BuilderE5.class)
+            .register(BuilderE6.class)
+            .register(BuilderF.class)
+            .register(BuilderG.class)
+            .register(BuilderH.class)
+            .register(BuilderI.class)
+            .register(BuilderJ.class)
+            .register(BuilderK.class);
 
     @Test
-	public void testGraphGeneration() throws Exception{
-		
-		DataFlow dataflow = new DataFlow();
-		dataflow.setDescription("Complex DataFlow");
-		dataflow.setEnabled(true);
-		dataflow.setTargetData("K");
-		dataflow.setTransients(Sets.newHashSet("IA","I"));
-		dataflow.setName("complext_flow");
-		
-		ExecutionGraphGenerator graphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
-		ExecutionGraph graph = graphGenerator.generateGraph(dataflow);
-		dataflow.setExecutionGraph(graph);
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.enable(SerializationFeature.INDENT_OUTPUT);
-		log.info(mapper.writeValueAsString(dataflow));
-	}
+    public void testGraphGeneration() throws Exception {
+
+        val dataflow = new DataFlow()
+                .setDescription("Complex DataFlow")
+                .setEnabled(true)
+                .setTargetData("K")
+                .setTransients(Sets.newHashSet("IA", "I"))
+                .setName("complext_flow");
+
+        val graphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
+        val graph = graphGenerator.generateGraph(dataflow);
+        dataflow.setExecutionGraph(graph);
+        val mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        log.info(mapper.writeValueAsString(dataflow));
+        val expected = mapper.readValue(
+                Files.readAllBytes(Paths.get(Objects.requireNonNull(this.getClass()
+                                                                            .getResource("/execgraphgentest.json"))
+                                                     .toURI())),
+                ExecutionGraph.class);
+        assertEquals(
+                expected.getDependencyHierarchy()
+                        .stream()
+                        .flatMap(Collection::stream)
+                        .map(DataBuilderMeta::getName)
+                        .sorted()
+                        .collect(Collectors.toList()),
+                graph.getDependencyHierarchy()
+                        .stream()
+                        .flatMap(Collection::stream)
+                        .map(DataBuilderMeta::getName)
+                        .sorted()
+                        .collect(Collectors.toList()));
+        assertEquals(
+                expected.getDependencyHierarchy()
+                        .stream()
+                        .flatMap(Collection::stream)
+                        .sorted(Comparator.comparing(DataBuilderMeta::getName))
+                        .map(DataBuilderMeta::getRank)
+                        .collect(Collectors.toList()),
+                graph.getDependencyHierarchy()
+                        .stream()
+                        .flatMap(Collection::stream)
+                        .sorted(Comparator.comparing(DataBuilderMeta::getName))
+                        .map(DataBuilderMeta::getRank)
+                        .collect(Collectors.toList()));
+    }
 
 }

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/TestBuilderOfSameRankNotBreakingInBetween.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/TestBuilderOfSameRankNotBreakingInBetween.java
@@ -1,104 +1,72 @@
 package io.appform.databuilderframework.cmplxscenariotest;
 
+import com.google.common.collect.Sets;
+import io.appform.databuilderframework.cmplxscenariotest.builders.*;
+import io.appform.databuilderframework.cmplxscenariotest.data.DataA;
+import io.appform.databuilderframework.cmplxscenariotest.data.InputAData;
+import io.appform.databuilderframework.engine.*;
+import io.appform.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
+import io.appform.databuilderframework.model.DataFlow;
+import io.appform.databuilderframework.model.DataFlowInstance;
+import lombok.val;
+import org.junit.Test;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderA1;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderA2;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderA3;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderB1;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderB2;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderB3;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderB4;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderB5;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderC;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderD;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderE1;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderE2;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderE3;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderE4;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderE5;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderE6;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderF;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderG;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderH;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderI;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderJ;
-import io.appform.databuilderframework.cmplxscenariotest.builders.BuilderK;
-import io.appform.databuilderframework.cmplxscenariotest.data.DataA;
-import io.appform.databuilderframework.cmplxscenariotest.data.DataI;
-import io.appform.databuilderframework.cmplxscenariotest.data.InputAData;
-import io.appform.databuilderframework.engine.DataBuilderFrameworkException;
-import io.appform.databuilderframework.engine.DataBuilderMetadataManager;
-import io.appform.databuilderframework.engine.DataValidationException;
-import io.appform.databuilderframework.engine.ExecutionGraphGenerator;
-import io.appform.databuilderframework.engine.MultiThreadedDataFlowExecutor;
-import io.appform.databuilderframework.engine.SimpleDataFlowExecutor;
-import io.appform.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
-import io.appform.databuilderframework.model.DataExecutionResponse;
-import io.appform.databuilderframework.model.DataFlow;
-import io.appform.databuilderframework.model.DataFlowInstance;
-import io.appform.databuilderframework.model.ExecutionGraph;
-import com.google.common.collect.Sets;
+import static org.junit.Assert.assertTrue;
 
 public class TestBuilderOfSameRankNotBreakingInBetween {
 
-	private final DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
-	private final SimpleDataFlowExecutor se = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
-//	private final ProfileExecutor builderExecutor = new ProfileExecutor(200, 250);
-	private final ExecutorService builderExecutor  = Executors.newFixedThreadPool(200);
-	private final MultiThreadedDataFlowExecutor me =  new MultiThreadedDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager),builderExecutor);;
+    private final DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager()
+            .register(BuilderA1.class)
+            .register(BuilderA2.class)
+            .register(BuilderA3.class)
+            .register(BuilderB1.class)
+            .register(BuilderB2.class)
+            .register(BuilderB3.class)
+            .register(BuilderB4.class)
+            .register(BuilderB5.class)
+            .register(BuilderC.class)
+            .register(BuilderD.class)
+            .register(BuilderE1.class)
+            .register(BuilderE2.class)
+            .register(BuilderE3.class)
+            .register(BuilderE4.class)
+            .register(BuilderE5.class)
+            .register(BuilderE6.class)
+            .register(BuilderF.class)
+            .register(BuilderG.class)
+            .register(BuilderH.class)
+            .register(BuilderI.class)
+            .register(BuilderJ.class)
+            .register(BuilderK.class);
+    private final SimpleDataFlowExecutor se = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(
+            dataBuilderMetadataManager));
+    //	private final ProfileExecutor builderExecutor = new ProfileExecutor(200, 250);
+    private final ExecutorService builderExecutor = Executors.newFixedThreadPool(200);
+    private final MultiThreadedDataFlowExecutor me
+            = new MultiThreadedDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager), builderExecutor);
 
-	@Before
-	public void setup() throws Exception {
-		dataBuilderMetadataManager.register(BuilderA1.class);
-		dataBuilderMetadataManager.register(BuilderA2.class);
-		dataBuilderMetadataManager.register(BuilderA3.class);
-		dataBuilderMetadataManager.register(BuilderB1.class);
-		dataBuilderMetadataManager.register(BuilderB2.class);
-		dataBuilderMetadataManager.register(BuilderB3.class);
-		dataBuilderMetadataManager.register(BuilderB4.class);
-		dataBuilderMetadataManager.register(BuilderB5.class);
-		dataBuilderMetadataManager.register(BuilderC.class);
-		dataBuilderMetadataManager.register(BuilderD.class);
-		dataBuilderMetadataManager.register(BuilderE1.class);
-		dataBuilderMetadataManager.register(BuilderE2.class);
-		dataBuilderMetadataManager.register(BuilderE3.class);
-		dataBuilderMetadataManager.register(BuilderE4.class);
-		dataBuilderMetadataManager.register(BuilderE5.class);
-		dataBuilderMetadataManager.register(BuilderE6.class);
-		dataBuilderMetadataManager.register(BuilderF.class);
-		dataBuilderMetadataManager.register(BuilderG.class);
-		dataBuilderMetadataManager.register(BuilderH.class);
-		dataBuilderMetadataManager.register(BuilderI.class);
-		dataBuilderMetadataManager.register(BuilderJ.class);
-		dataBuilderMetadataManager.register(BuilderK.class);
-	}
+    @Test
+    public void testToCheckIfBuilderA2RunsEvenWhenRankIsLess() throws DataBuilderFrameworkException, DataValidationException {
+        val dataflow = new DataFlow()
+                .setDescription("Complex DataFlow")
+                .setEnabled(true)
+                .setTargetData("K")
+                .setTransients(Sets.newHashSet("IA", "I"))
+                .setName("complext_flow");
 
-	@Test
-	public void testToCheckIfBuilderA2RunsEvenWhenRankIsLess() throws DataBuilderFrameworkException, DataValidationException{
-		DataFlow dataflow = new DataFlow();
-		dataflow.setDescription("Complex DataFlow");
-		dataflow.setEnabled(true);
-		dataflow.setTargetData("K");
-		dataflow.setTransients(Sets.newHashSet("IA","I"));
-		dataflow.setName("complext_flow");
+        val graphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
+        val graph = graphGenerator.generateGraph(dataflow);
+        dataflow.setExecutionGraph(graph);
 
-		ExecutionGraphGenerator graphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
-		ExecutionGraph graph = graphGenerator.generateGraph(dataflow);
-		dataflow.setExecutionGraph(graph);
+        val instance = new DataFlowInstance("test", dataflow);
+        val resp = se.run(instance, new DataA(8), new InputAData());
+        assertTrue(resp.getResponses().containsKey("K"));
 
-		final DataFlow dataflowRef = dataflow;
-		final DataFlowInstance instance  = new DataFlowInstance("test", dataflowRef);
-		DataExecutionResponse resp = se.run(instance, new DataA(8), new InputAData());
-		Assert.assertEquals(true,resp.getResponses().containsKey("K"));
-		
-		final DataFlowInstance meInstance  = new DataFlowInstance("test2", dataflowRef);
-		DataExecutionResponse resp2 = me.run(instance, new DataA(8), new InputAData());
-		Assert.assertEquals(true,resp2.getResponses().containsKey("K"));
-	}
+        val meInstance = new DataFlowInstance("test2", dataflow);
+        val resp2 = me.run(meInstance, new DataA(8), new InputAData());
+        assertTrue(resp2.getResponses().containsKey("K"));
+    }
 }

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/ThreadUtils.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/ThreadUtils.java
@@ -8,7 +8,6 @@ package io.appform.databuilderframework.cmplxscenariotest;
 public enum ThreadUtils {
 	INSTANCE;
 
-
 	public void putToSleep(int duration,String builderName){
 		String name = Thread.currentThread().getName().split(":")[0];
 		try {

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderA1.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderA1.java
@@ -7,10 +7,10 @@ import io.appform.databuilderframework.cmplxscenariotest.data.DataA1;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.engine.DataValidationException;
 import io.appform.databuilderframework.model.Data;
 import io.appform.databuilderframework.model.DataSet;
+import lombok.val;
 
 @DataBuilderInfo(name = "BuilderA1", consumes = {"A"}, produces = "A1")
 public class BuilderA1 extends DataBuilder{
@@ -18,8 +18,8 @@ public class BuilderA1 extends DataBuilder{
 	@Override
 	public Data process(DataBuilderContext context)
 			throws DataBuilderException, DataValidationException {
-		DataSetAccessor dataSetAccessor = DataSet.accessor(context.getDataSet());
-		DataA dataA = dataSetAccessor.get("A", DataA.class);
+		val dataSetAccessor = DataSet.accessor(context.getDataSet());
+		val dataA = dataSetAccessor.get("A", DataA.class);
 		ThreadUtils.INSTANCE.putToSleep(20, "A1");
 		if(dataA.val <= 7){ //70% of case this builder will run and genrate data
 			return new DataA1();

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderA2.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderA2.java
@@ -7,10 +7,10 @@ import io.appform.databuilderframework.cmplxscenariotest.data.DataA2;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.engine.DataValidationException;
 import io.appform.databuilderframework.model.Data;
 import io.appform.databuilderframework.model.DataSet;
+import lombok.val;
 
 @DataBuilderInfo(name = "BuilderA2", consumes = {"A"}, produces = "A2")
 public class BuilderA2 extends DataBuilder{
@@ -18,9 +18,9 @@ public class BuilderA2 extends DataBuilder{
 	@Override
 	public Data process(DataBuilderContext context)
 			throws DataBuilderException, DataValidationException {
-		DataSetAccessor dataSetAccessor = DataSet.accessor(context.getDataSet());
-		DataA dataA = dataSetAccessor.get("A", DataA.class);
-		String name = Thread.currentThread().getName();
+		val dataSetAccessor = DataSet.accessor(context.getDataSet());
+		val dataA = dataSetAccessor.get("A", DataA.class);
+		val name = Thread.currentThread().getName();
 		if(dataA.val > 7){ // this builder will run when BuilderA1 is not running
 			ThreadUtils.INSTANCE.putToSleep(20, "A2");
 			return new DataA2();

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderA3.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderA3.java
@@ -6,10 +6,10 @@ import io.appform.databuilderframework.cmplxscenariotest.data.DataA3;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.engine.DataValidationException;
 import io.appform.databuilderframework.model.Data;
 import io.appform.databuilderframework.model.DataSet;
+import lombok.val;
 
 @DataBuilderInfo(name = "BuilderA3", consumes = {"A","IA"}, produces = "A3")
 public class BuilderA3 extends DataBuilder{
@@ -17,7 +17,7 @@ public class BuilderA3 extends DataBuilder{
 	@Override
 	public Data process(DataBuilderContext context)
 			throws DataBuilderException, DataValidationException {
-		DataSetAccessor dataSetAccessor = DataSet.accessor(context.getDataSet());
+		val dataSetAccessor = DataSet.accessor(context.getDataSet());
 		ThreadUtils.INSTANCE.putToSleep(20, "A3");
 		return new DataA3();
 	}

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderB1.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderB1.java
@@ -6,10 +6,10 @@ import io.appform.databuilderframework.cmplxscenariotest.data.DataB1;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.engine.DataValidationException;
 import io.appform.databuilderframework.model.Data;
 import io.appform.databuilderframework.model.DataSet;
+import lombok.val;
 
 @DataBuilderInfo(name = "BuilderB1", consumes = {"A", "A1"}, produces = "B1")
 public class BuilderB1 extends DataBuilder{
@@ -17,7 +17,7 @@ public class BuilderB1 extends DataBuilder{
 	@Override
 	public Data process(DataBuilderContext context)
 			throws DataBuilderException, DataValidationException {
-		DataSetAccessor dataSetAccessor = DataSet.accessor(context.getDataSet());
+		val dataSetAccessor = DataSet.accessor(context.getDataSet());
 		ThreadUtils.INSTANCE.putToSleep(20, "B1");
 		return new DataB1();
 	}

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderC.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderC.java
@@ -6,10 +6,10 @@ import io.appform.databuilderframework.cmplxscenariotest.data.DataC;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.engine.DataValidationException;
 import io.appform.databuilderframework.model.Data;
 import io.appform.databuilderframework.model.DataSet;
+import lombok.val;
 
 @DataBuilderInfo(name = "BuilderC", consumes = {"A"},
 optionals={"A1","A2","B1","B2", "B3", "B4", "B5"}, produces = "C")
@@ -18,7 +18,7 @@ public class BuilderC extends DataBuilder{
 	@Override
 	public Data process(DataBuilderContext context)
 			throws DataBuilderException, DataValidationException {
-		DataSetAccessor accessor = DataSet.accessor(context.getDataSet());
+		val accessor = DataSet.accessor(context.getDataSet());
 		if(accessor.checkForData("A1")){
 			if(accessor.checkForData("B1") &&
 					accessor.checkForData("B2") &&

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderE1.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderE1.java
@@ -7,10 +7,10 @@ import io.appform.databuilderframework.cmplxscenariotest.data.DataE1;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.engine.DataValidationException;
 import io.appform.databuilderframework.model.Data;
 import io.appform.databuilderframework.model.DataSet;
+import lombok.val;
 
 @DataBuilderInfo(name = "BuilderE1", accesses={"A","C"}, consumes = {"D"}, produces = "E1")
 public class BuilderE1 extends DataBuilder{
@@ -18,8 +18,8 @@ public class BuilderE1 extends DataBuilder{
 	@Override
 	public Data process(DataBuilderContext context)
 			throws DataBuilderException, DataValidationException {
-		DataSetAccessor dataSetAccessor = DataSet.accessor(context.getDataSet());
-		DataD dataD = dataSetAccessor.get("D", DataD.class);
+		val dataSetAccessor = DataSet.accessor(context.getDataSet());
+		val dataD = dataSetAccessor.get("D", DataD.class);
 		if(dataD.val == 0){ // RUN FOR 0 VAL
 			ThreadUtils.INSTANCE.putToSleep(20, "E1");
 			return new DataE1();

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderE2.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderE2.java
@@ -7,10 +7,10 @@ import io.appform.databuilderframework.cmplxscenariotest.data.DataE2;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.engine.DataValidationException;
 import io.appform.databuilderframework.model.Data;
 import io.appform.databuilderframework.model.DataSet;
+import lombok.val;
 
 @DataBuilderInfo(name = "BuilderE2", accesses={"A","C"}, consumes = {"D"}, produces = "E2")
 public class BuilderE2 extends DataBuilder{
@@ -18,8 +18,8 @@ public class BuilderE2 extends DataBuilder{
 	@Override
 	public Data process(DataBuilderContext context)
 			throws DataBuilderException, DataValidationException {
-		DataSetAccessor dataSetAccessor = DataSet.accessor(context.getDataSet());
-		DataD dataD = dataSetAccessor.get("D", DataD.class);
+		val dataSetAccessor = DataSet.accessor(context.getDataSet());
+		val dataD = dataSetAccessor.get("D", DataD.class);
 		if(dataD.val <= 2){ // RUN FOR 2 VAL
 			ThreadUtils.INSTANCE.putToSleep(20, "E2");
 			return new DataE2();

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderE3.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderE3.java
@@ -7,10 +7,10 @@ import io.appform.databuilderframework.cmplxscenariotest.data.DataE3;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.engine.DataValidationException;
 import io.appform.databuilderframework.model.Data;
 import io.appform.databuilderframework.model.DataSet;
+import lombok.val;
 
 @DataBuilderInfo(name = "BuilderE3", accesses={"A","C"}, consumes = {"D"}, produces = "E3")
 public class BuilderE3 extends DataBuilder{
@@ -18,8 +18,8 @@ public class BuilderE3 extends DataBuilder{
 	@Override
 	public Data process(DataBuilderContext context)
 			throws DataBuilderException, DataValidationException {
-		DataSetAccessor dataSetAccessor = DataSet.accessor(context.getDataSet());
-		DataD dataD = dataSetAccessor.get("D", DataD.class);
+		val dataSetAccessor = DataSet.accessor(context.getDataSet());
+		val dataD = dataSetAccessor.get("D", DataD.class);
 		if(dataD.val <= 2){ // RUN FOR 2 VAL
 			ThreadUtils.INSTANCE.putToSleep(20, "E3");
 			return new DataE3();

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderE4.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderE4.java
@@ -7,10 +7,10 @@ import io.appform.databuilderframework.cmplxscenariotest.data.DataE4;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.engine.DataValidationException;
 import io.appform.databuilderframework.model.Data;
 import io.appform.databuilderframework.model.DataSet;
+import lombok.val;
 
 @DataBuilderInfo(name = "BuilderE4", accesses={"A","C"}, consumes = {"D"}, produces = "E4")
 public class BuilderE4 extends DataBuilder{
@@ -18,8 +18,8 @@ public class BuilderE4 extends DataBuilder{
 	@Override
 	public Data process(DataBuilderContext context)
 			throws DataBuilderException, DataValidationException {
-		DataSetAccessor dataSetAccessor = DataSet.accessor(context.getDataSet());
-		DataD dataD = dataSetAccessor.get("D", DataD.class);
+		val dataSetAccessor = DataSet.accessor(context.getDataSet());
+		val dataD = dataSetAccessor.get("D", DataD.class);
 		if(dataD.val <= 3){ // RUN FOR 2 VAL
 			ThreadUtils.INSTANCE.putToSleep(20, "E4");
 			return new DataE4();

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderE5.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderE5.java
@@ -7,10 +7,10 @@ import io.appform.databuilderframework.cmplxscenariotest.data.DataE5;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.engine.DataValidationException;
 import io.appform.databuilderframework.model.Data;
 import io.appform.databuilderframework.model.DataSet;
+import lombok.val;
 
 @DataBuilderInfo(name = "BuilderE5", accesses={"A","C"}, consumes = {"D"}, produces = "E5")
 public class BuilderE5 extends DataBuilder{
@@ -18,8 +18,8 @@ public class BuilderE5 extends DataBuilder{
 	@Override
 	public Data process(DataBuilderContext context)
 			throws DataBuilderException, DataValidationException {
-		DataSetAccessor dataSetAccessor = DataSet.accessor(context.getDataSet());
-		DataD dataD = dataSetAccessor.get("D", DataD.class);
+		val dataSetAccessor = DataSet.accessor(context.getDataSet());
+		val dataD = dataSetAccessor.get("D", DataD.class);
 		if(dataD.val <= 4){ // RUN FOR 2 VAL
 			ThreadUtils.INSTANCE.putToSleep(20, "E5");
 			return new DataE5();

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderE6.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderE6.java
@@ -6,10 +6,8 @@ import io.appform.databuilderframework.cmplxscenariotest.data.DataE6;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.engine.DataValidationException;
 import io.appform.databuilderframework.model.Data;
-import io.appform.databuilderframework.model.DataSet;
 
 @DataBuilderInfo(name = "BuilderE6", accesses={"A","C"}, consumes = {"D","IE6"}, produces = "E6")
 public class BuilderE6 extends DataBuilder{
@@ -18,7 +16,6 @@ public class BuilderE6 extends DataBuilder{
 	public Data process(DataBuilderContext context)
 			throws DataBuilderException, DataValidationException {
 		ThreadUtils.INSTANCE.putToSleep(20, "E6");
-		DataSetAccessor dataSetAccessor = DataSet.accessor(context.getDataSet());
 		return new DataE6();
 	}
 

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderF.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderF.java
@@ -6,10 +6,8 @@ import io.appform.databuilderframework.cmplxscenariotest.data.DataF;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.engine.DataValidationException;
 import io.appform.databuilderframework.model.Data;
-import io.appform.databuilderframework.model.DataSet;
 
 @DataBuilderInfo(name = "BuilderF", accesses={"A","C","D"}, consumes = {"E1"}, produces = "F")
 public class BuilderF extends DataBuilder{
@@ -18,7 +16,6 @@ public class BuilderF extends DataBuilder{
 	public Data process(DataBuilderContext context)
 			throws DataBuilderException, DataValidationException {
 		ThreadUtils.INSTANCE.putToSleep(20, "F");
-		DataSetAccessor dataSetAccessor = DataSet.accessor(context.getDataSet());
 		return new DataF();
 	}
 

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderG.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderG.java
@@ -6,10 +6,8 @@ import io.appform.databuilderframework.cmplxscenariotest.data.DataG;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.engine.DataValidationException;
 import io.appform.databuilderframework.model.Data;
-import io.appform.databuilderframework.model.DataSet;
 
 @DataBuilderInfo(name = "BuilderG", accesses={"C","D","E1"}, consumes = {"F"}, produces = "G")
 public class BuilderG extends DataBuilder{
@@ -18,7 +16,6 @@ public class BuilderG extends DataBuilder{
 	public Data process(DataBuilderContext context)
 			throws DataBuilderException, DataValidationException {
 		ThreadUtils.INSTANCE.putToSleep(20, "G");
-		DataSetAccessor dataSetAccessor = DataSet.accessor(context.getDataSet());
 		return new DataG();
 	}
 

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderH.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderH.java
@@ -6,10 +6,8 @@ import io.appform.databuilderframework.cmplxscenariotest.data.DataH;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.engine.DataValidationException;
 import io.appform.databuilderframework.model.Data;
-import io.appform.databuilderframework.model.DataSet;
 
 @DataBuilderInfo(name = "BuilderH", accesses={"A","C","D"}, consumes = {"G"},
 	optionals ={"E2","E3","E4","F","G"}, produces = "H")
@@ -19,7 +17,6 @@ public class BuilderH extends DataBuilder{
 	public Data process(DataBuilderContext context)
 			throws DataBuilderException, DataValidationException {
 		ThreadUtils.INSTANCE.putToSleep(20, "G");
-		DataSetAccessor dataSetAccessor = DataSet.accessor(context.getDataSet());
 		return new DataH();
 	}
 

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderI.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderI.java
@@ -6,10 +6,8 @@ import io.appform.databuilderframework.cmplxscenariotest.data.DataI;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.engine.DataValidationException;
 import io.appform.databuilderframework.model.Data;
-import io.appform.databuilderframework.model.DataSet;
 
 @DataBuilderInfo(name = "BuilderI", accesses={"A"},
 	optionals={"E2","E3","E4","E5","E6","F","G","IE6"}, 
@@ -20,7 +18,6 @@ public class BuilderI extends DataBuilder{
 	public Data process(DataBuilderContext context)
 			throws DataBuilderException, DataValidationException {
 		ThreadUtils.INSTANCE.putToSleep(20, "I");
-		DataSetAccessor dataSetAccessor = DataSet.accessor(context.getDataSet());
 		return new DataI();
 	}
 

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderJ.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderJ.java
@@ -6,10 +6,8 @@ import io.appform.databuilderframework.cmplxscenariotest.data.DataJ;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.engine.DataValidationException;
 import io.appform.databuilderframework.model.Data;
-import io.appform.databuilderframework.model.DataSet;
 
 @DataBuilderInfo(name = "BuilderJ",
 	accesses={"A", "E2","E3","E4","E5","E6","F","G","IE6", "J"}, 
@@ -20,7 +18,6 @@ public class BuilderJ extends DataBuilder{
 	public Data process(DataBuilderContext context)
 			throws DataBuilderException, DataValidationException {
 		ThreadUtils.INSTANCE.putToSleep(20, "J");
-		DataSetAccessor dataSetAccessor = DataSet.accessor(context.getDataSet());
 		return new DataJ();
 	}
 

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderK.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/builders/BuilderK.java
@@ -6,10 +6,8 @@ import io.appform.databuilderframework.cmplxscenariotest.data.DataK;
 import io.appform.databuilderframework.engine.DataBuilder;
 import io.appform.databuilderframework.engine.DataBuilderContext;
 import io.appform.databuilderframework.engine.DataBuilderException;
-import io.appform.databuilderframework.engine.DataSetAccessor;
 import io.appform.databuilderframework.engine.DataValidationException;
 import io.appform.databuilderframework.model.Data;
-import io.appform.databuilderframework.model.DataSet;
 
 @DataBuilderInfo(name = "BuilderK",
 	accesses={"A", "C"}, 
@@ -20,7 +18,6 @@ public class BuilderK extends DataBuilder{
 	public Data process(DataBuilderContext context)
 			throws DataBuilderException, DataValidationException {
 		ThreadUtils.INSTANCE.putToSleep(20, "K");
-		DataSetAccessor dataSetAccessor = DataSet.accessor(context.getDataSet());
 		return new DataK();
 	}
 

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/data/DataA.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/data/DataA.java
@@ -1,20 +1,25 @@
 package io.appform.databuilderframework.cmplxscenariotest.data;
 
 import io.appform.databuilderframework.model.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
-public class DataA extends Data{
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class DataA extends Data {
 
-	public final int val;
-	public DataA() {
-		super("A");
-		this.val = (int) (Math.random()*10);
-		
-	}
-	
-	public DataA(int val) {
-		super("A");
-		this.val = val;
-		
-	}
+    public int val;
+
+    public DataA() {
+        super("A");
+        this.val = (int) (Math.random() * 10);
+
+    }
+
+    public DataA(int val) {
+        super("A");
+        this.val = val;
+
+    }
 
 }

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/data/DataD.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/data/DataD.java
@@ -1,13 +1,18 @@
 package io.appform.databuilderframework.cmplxscenariotest.data;
 
 import io.appform.databuilderframework.model.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
-public class DataD extends Data{
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class DataD extends Data {
 
-	public final int val;
-	public DataD() {
-		super("D");
-		this.val = (int) (Math.random()* 5);
-	}
+    public int val;
+
+    public DataD() {
+        super("D");
+        this.val = (int) (Math.random() * 5);
+    }
 
 }

--- a/src/test/java/io/appform/databuilderframework/cmplxscenariotest/data/DataE1.java
+++ b/src/test/java/io/appform/databuilderframework/cmplxscenariotest/data/DataE1.java
@@ -2,10 +2,10 @@ package io.appform.databuilderframework.cmplxscenariotest.data;
 
 import io.appform.databuilderframework.model.Data;
 
-public class DataE1 extends Data{
+public class DataE1 extends Data {
 
-	public DataE1() {
-		super("E1");
-	}
+    public DataE1() {
+        super("E1");
+    }
 
 }

--- a/src/test/java/io/appform/databuilderframework/complextest/ComplexFlowTest.java
+++ b/src/test/java/io/appform/databuilderframework/complextest/ComplexFlowTest.java
@@ -1,29 +1,35 @@
 package io.appform.databuilderframework.complextest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import io.appform.databuilderframework.engine.DataBuilderMetadataManager;
 import io.appform.databuilderframework.engine.DataFlowExecutor;
 import io.appform.databuilderframework.engine.ExecutionGraphGenerator;
 import io.appform.databuilderframework.engine.SimpleDataFlowExecutor;
 import io.appform.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
 import io.appform.databuilderframework.model.*;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @Slf4j
 public class ComplexFlowTest {
-    private DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
-    private DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
-    private ExecutionGraphGenerator executionGraphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
-    public ComplexFlowTest() throws Exception {
-        dataBuilderMetadataManager.register(ImmutableSet.of("CR", "CAID", "VAS"), "OO", "SB", SB.class);
-        dataBuilderMetadataManager.register(ImmutableSet.of("OO"), "POD", "POB", POB.class);
-        dataBuilderMetadataManager.register(ImmutableSet.of("OO", "POD", "SPD"), "ILD", "PRB", PRB.class);
-        dataBuilderMetadataManager.register(ImmutableSet.of("ILD", "EPD"), "OSD", "PPB", PPB.class);
-        dataBuilderMetadataManager.register(ImmutableSet.of("OO", "OSD"), "OCD", "COB", COB.class);
-    }
+    private final DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager()
+            .register(ImmutableSet.of("CR", "CAID", "VAS"), "OO", "SB", SB.class)
+            .register(ImmutableSet.of("OO"), "POD", "POB", POB.class)
+            .register(ImmutableSet.of("OO", "POD", "SPD"), "ILD", "PRB", PRB.class)
+            .register(ImmutableSet.of("ILD", "EPD"), "OSD", "PPB", PPB.class)
+            .register(ImmutableSet.of("OO", "OSD"), "OCD", "COB", COB.class);
+
+    private final DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(
+            dataBuilderMetadataManager));
+
+    private final ExecutionGraphGenerator executionGraphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
+
 
     @Test
     public void testRunWeb() throws Exception {
@@ -40,16 +46,27 @@ public class ComplexFlowTest {
             DataDelta dataDelta = new DataDelta(Lists.newArrayList(new CR(), new CAID(), new VAS()));
             DataExecutionResponse response = executor.run(complexFlowIntsnace, dataDelta);
             log.info(new ObjectMapper().writeValueAsString(response));
+            val responses = response.getResponses();
+            assertEquals(2, responses.size());
+            assertTrue(responses.containsKey("OO"));
+            assertTrue(responses.containsKey("POD"));
         }
         {
             DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new SPD()));
             DataExecutionResponse response = executor.run(complexFlowIntsnace, dataDelta);
             log.info(new ObjectMapper().writeValueAsString(response));
+            val responses = response.getResponses();
+            assertEquals(1, responses.size());
+            assertTrue(responses.containsKey("ILD"));
         }
         {
             DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new EPD()));
             DataExecutionResponse response = executor.run(complexFlowIntsnace, dataDelta);
             log.info(new ObjectMapper().writeValueAsString(response));
+            val responses = response.getResponses();
+            assertEquals(2, responses.size());
+            assertTrue(responses.containsKey("OCD"));
+            assertTrue(responses.containsKey("OSD"));
         }
 
     }
@@ -66,14 +83,24 @@ public class ComplexFlowTest {
 
         DataFlowInstance complexFlowIntsnace = new DataFlowInstance("Test", dataFlow, new DataSet());
         {
-            DataDelta dataDelta = new DataDelta(Lists.newArrayList(new CR(), new CAID(), new VAS(), new SPD()));
-            DataExecutionResponse response = executor.run(complexFlowIntsnace, dataDelta);
+            val dataDelta = new DataDelta(Lists.newArrayList(new CR(), new CAID(), new VAS(), new SPD()));
+            val response = executor.run(complexFlowIntsnace, dataDelta);
             log.info(new ObjectMapper().writeValueAsString(response));
+            val responses = response.getResponses();
+            assertEquals(3, responses.size());
+            assertTrue(responses.containsKey("OO"));
+            assertTrue(responses.containsKey("POD"));
+            assertTrue(responses.containsKey("ILD"));
+
         }
         {
             DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(new EPD()));
             DataExecutionResponse response = executor.run(complexFlowIntsnace, dataDelta);
             log.info(new ObjectMapper().writeValueAsString(response));
+            val responses = response.getResponses();
+            assertEquals(2, responses.size());
+            assertTrue(responses.containsKey("OCD"));
+            assertTrue(responses.containsKey("OSD"));
         }
 
     }
@@ -90,9 +117,20 @@ public class ComplexFlowTest {
 
         DataFlowInstance complexFlowIntsnace = new DataFlowInstance("Test", dataFlow, new DataSet());
         {
-            DataDelta dataDelta = new DataDelta(Lists.newArrayList(new CR(), new CAID(), new VAS(), new SPD(), new EPD()));
+            DataDelta dataDelta = new DataDelta(Lists.newArrayList(new CR(),
+                                                                   new CAID(),
+                                                                   new VAS(),
+                                                                   new SPD(),
+                                                                   new EPD()));
             DataExecutionResponse response = executor.run(complexFlowIntsnace, dataDelta);
             log.info(new ObjectMapper().writeValueAsString(response));
+            val responses = response.getResponses();
+            assertEquals(5, responses.size());
+            assertTrue(responses.containsKey("OCD"));
+            assertTrue(responses.containsKey("OSD"));
+            assertTrue(responses.containsKey("ILD"));
+            assertTrue(responses.containsKey("OO"));
+            assertTrue(responses.containsKey("POD"));
         }
 
     }

--- a/src/test/java/io/appform/databuilderframework/complextest/ExampleTest.java
+++ b/src/test/java/io/appform/databuilderframework/complextest/ExampleTest.java
@@ -1,5 +1,6 @@
 package io.appform.databuilderframework.complextest;
 
+import com.google.common.collect.ImmutableSet;
 import io.appform.databuilderframework.TestBuilderA;
 import io.appform.databuilderframework.TestBuilderB;
 import io.appform.databuilderframework.TestBuilderC;
@@ -7,45 +8,45 @@ import io.appform.databuilderframework.TestBuilderD;
 import io.appform.databuilderframework.engine.DataBuilderMetadataManager;
 import io.appform.databuilderframework.engine.ExecutionGraphGenerator;
 import io.appform.databuilderframework.model.DataFlow;
-import io.appform.databuilderframework.model.ExecutionGraph;
-import com.google.common.collect.ImmutableSet;
-import org.junit.Assert;
+import lombok.val;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ExampleTest {
 
     @Test
     public void testBalancedTree() throws Exception {
-        DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
-        ExecutionGraphGenerator executionGraphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
-        dataBuilderMetadataManager.register(ImmutableSet.of("A", "B"), "C", "BuilderA", TestBuilderA.class );
-        dataBuilderMetadataManager.register(ImmutableSet.of("D", "E"), "F", "BuilderC", TestBuilderB.class );
-        dataBuilderMetadataManager.register(ImmutableSet.of("C", "F"), "G", "BuilderD", TestBuilderC.class );
-        DataFlow dataFlow = new DataFlow();
-        dataFlow.setName("test");
-        dataFlow.setTargetData("G");
-        ExecutionGraph e = executionGraphGenerator.generateGraph(dataFlow);
-        Assert.assertEquals(2, e.getDependencyHierarchy().size());
-        Assert.assertEquals(2, e.getDependencyHierarchy().get(0).size());
-        Assert.assertEquals(1, e.getDependencyHierarchy().get(1).size());
+        val dataBuilderMetadataManager = new DataBuilderMetadataManager()
+                .register(ImmutableSet.of("A", "B"), "C", "BuilderA", TestBuilderA.class)
+                .register(ImmutableSet.of("D", "E"), "F", "BuilderC", TestBuilderB.class)
+                .register(ImmutableSet.of("C", "F"), "G", "BuilderD", TestBuilderC.class);
+        val executionGraphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
+        val dataFlow = new DataFlow()
+                .setName("test")
+                .setTargetData("G");
+        val e = executionGraphGenerator.generateGraph(dataFlow);
+        assertEquals(2, e.getDependencyHierarchy().size());
+        assertEquals(2, e.getDependencyHierarchy().get(0).size());
+        assertEquals(1, e.getDependencyHierarchy().get(1).size());
     }
 
     @Test
     public void testDiamond() throws Exception {
-        DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
-        ExecutionGraphGenerator executionGraphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
-        dataBuilderMetadataManager.register(ImmutableSet.of("A", "B"), "C", "BuilderA", TestBuilderA.class );
-        dataBuilderMetadataManager.register(ImmutableSet.of("C", "E"), "F", "BuilderB", TestBuilderB.class );
-        dataBuilderMetadataManager.register(ImmutableSet.of("C", "G"), "H", "BuilderC", TestBuilderC.class );
-        dataBuilderMetadataManager.register(ImmutableSet.of("F", "H"), "X", "BuilderD", TestBuilderD.class );
-        DataFlow dataFlow = new DataFlow();
-        dataFlow.setName("test");
-        dataFlow.setTargetData("X");
-        ExecutionGraph e = executionGraphGenerator.generateGraph(dataFlow);
-        Assert.assertEquals(3, e.getDependencyHierarchy().size());
-        Assert.assertEquals(1, e.getDependencyHierarchy().get(0).size());
-        Assert.assertEquals(2, e.getDependencyHierarchy().get(1).size());
-        Assert.assertEquals(1, e.getDependencyHierarchy().get(2).size());
+        val dataBuilderMetadataManager = new DataBuilderMetadataManager()
+                .register(ImmutableSet.of("A", "B"), "C", "BuilderA", TestBuilderA.class)
+                .register(ImmutableSet.of("C", "E"), "F", "BuilderB", TestBuilderB.class)
+                .register(ImmutableSet.of("C", "G"), "H", "BuilderC", TestBuilderC.class)
+                .register(ImmutableSet.of("F", "H"), "X", "BuilderD", TestBuilderD.class);
+        val executionGraphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
+        val dataFlow = new DataFlow()
+                .setName("test")
+                .setTargetData("X");
+        val e = executionGraphGenerator.generateGraph(dataFlow);
+        assertEquals(3, e.getDependencyHierarchy().size());
+        assertEquals(1, e.getDependencyHierarchy().get(0).size());
+        assertEquals(2, e.getDependencyHierarchy().get(1).size());
+        assertEquals(1, e.getDependencyHierarchy().get(2).size());
     }
 
 }

--- a/src/test/java/io/appform/databuilderframework/databuilderinstancetest/DataFlowBuilderTest.java
+++ b/src/test/java/io/appform/databuilderframework/databuilderinstancetest/DataFlowBuilderTest.java
@@ -2,9 +2,14 @@ package io.appform.databuilderframework.databuilderinstancetest;
 
 import io.appform.databuilderframework.annotations.DataBuilderClassInfo;
 import io.appform.databuilderframework.engine.*;
-import io.appform.databuilderframework.model.*;
-import org.junit.Assert;
+import io.appform.databuilderframework.model.Data;
+import io.appform.databuilderframework.model.DataAdapter;
+import io.appform.databuilderframework.model.DataDelta;
+import io.appform.databuilderframework.model.DataFlowInstance;
+import lombok.val;
 import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 public class DataFlowBuilderTest {
 
@@ -57,18 +62,18 @@ public class DataFlowBuilderTest {
 
     @Test
     public void testInstantiatingBuilder() throws Exception {
-        DataFlow dataFlow = new DataFlowBuilder()
+        val dataFlow = new DataFlowBuilder()
                                         .withDataBuilder(new BuilderA())
                                         .withTargetData(TestDataC.class)
                                         .build();
-        DataFlowExecutor executor = new SimpleDataFlowExecutor();
-        DataFlowInstance instance = new DataFlowInstance();
+        val executor = new SimpleDataFlowExecutor();
+        val instance = new DataFlowInstance();
         instance.setDataFlow(dataFlow);
-        DataExecutionResponse response = executor.run(instance,
+        val response = executor.run(instance,
                                                       new DataDelta(
                                                           new TestDataA("Hello"),
                                                           new TestDataB("Santanu")));
-        Assert.assertTrue(response.getResponses().containsKey(Utils.name(TestDataC.class)));
+        assertTrue(response.getResponses().containsKey(Utils.name(TestDataC.class)));
     }
 
 }

--- a/src/test/java/io/appform/databuilderframework/engine/DataBuilderMetadataManagerTest.java
+++ b/src/test/java/io/appform/databuilderframework/engine/DataBuilderMetadataManagerTest.java
@@ -1,17 +1,20 @@
 package io.appform.databuilderframework.engine;
 
-import io.appform.databuilderframework.complextest.SB;
 import com.google.common.collect.ImmutableSet;
-import org.junit.Assert;
+import io.appform.databuilderframework.complextest.SB;
+import lombok.val;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class DataBuilderMetadataManagerTest {
 
     @Test
     public void testGetConsumesSetFor() throws Exception {
-        DataBuilderMetadataManager manager = new DataBuilderMetadataManager();
-        Assert.assertEquals(null, manager.getConsumesSetFor("A"));
+        val manager = new DataBuilderMetadataManager();
+        assertNull(manager.getConsumesSetFor("A"));
         manager.register(ImmutableSet.of("CR", "CAID", "VAS"), "OO", "SB", SB.class);
-        Assert.assertEquals(1, manager.getConsumesSetFor("CR").size());
+        assertEquals(1, manager.getConsumesSetFor("CR").size());
     }
 }

--- a/src/test/java/io/appform/databuilderframework/flowtest/tests/FlowTest.java
+++ b/src/test/java/io/appform/databuilderframework/flowtest/tests/FlowTest.java
@@ -2,6 +2,9 @@ package io.appform.databuilderframework.flowtest.tests;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import io.appform.databuilderframework.engine.DataBuilderMetadataManager;
 import io.appform.databuilderframework.engine.DataFlowExecutor;
 import io.appform.databuilderframework.engine.ExecutionGraphGenerator;
@@ -10,36 +13,38 @@ import io.appform.databuilderframework.engine.impl.InstantiatingDataBuilderFacto
 import io.appform.databuilderframework.flowtest.builders.*;
 import io.appform.databuilderframework.flowtest.data.*;
 import io.appform.databuilderframework.model.*;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Assert;
+import lombok.val;
 import org.junit.Test;
 
 import java.util.Collection;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @Slf4j
 public class FlowTest {
-    private DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
-    private DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
-    private ExecutionGraphGenerator executionGraphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
-    private ObjectMapper mapper = new ObjectMapper();
+    private final DataBuilderMetadataManager dataBuilderMetadataManager
+            = new DataBuilderMetadataManager()
+            .register(ImmutableSet.of("CR", "CAID"), "OO", "OOB", OOBuilderTest.class)
+            .register(ImmutableSet.of("OO", "OMSP"), "OCRD", "OCRDB", OCOBuilder.class)
+            .register(ImmutableSet.of("OO", "CAID", "OMSP", "OCRD"), "POD", "PODB", POBuilder.class)
+            .register(ImmutableSet.of("SPD", "OO", "OCRD", "POD"), "ILD", "ILDB", ILBuilder.class)
+            .register(ImmutableSet.of("SPD", "ILD", "OO", "OCRD"), "IPD", "IPDB", IPBuilder.class)
+            .register(ImmutableSet.of("IPD", "EPD", "OO"), "DPD", "DPDB", DPBuilder.class)
+            .register(ImmutableSet.of("DPD", "IPD", "OO"), "OMSP", "OMSPD", OPBuilder.class)
+            .register(ImmutableSet.of("OMSP", "OO", "DPD"), "PSD", "PSDB", PSBuilder.class)
+            .register(ImmutableSet.of("PSD", "OMSP", "OO"), "PPD", "PPDB", PPBuilder.class)
+            .register(ImmutableSet.of("PPD", "PSD"), "OCD", "OCDB", OCBuilder.class);
+
+    private final DataFlowExecutor executor
+            = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
+
+    private final ExecutionGraphGenerator executionGraphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
+
+    private final ObjectMapper mapper = new ObjectMapper();
 
     public FlowTest() throws Exception {
-        dataBuilderMetadataManager.register(ImmutableSet.of("CR", "CAID"), "OO", "OOB", OOBuilderTest.class);
-        dataBuilderMetadataManager.register(ImmutableSet.of("OO", "OMSP"), "OCRD", "OCRDB", OCOBuilder.class);
-        dataBuilderMetadataManager.register(ImmutableSet.of("OO", "CAID", "OMSP", "OCRD"), "POD", "PODB", POBuilder.class);
-        dataBuilderMetadataManager.register(ImmutableSet.of("SPD", "OO", "OCRD", "POD"), "ILD", "ILDB", ILBuilder.class);
-        dataBuilderMetadataManager.register(ImmutableSet.of("SPD", "ILD", "OO", "OCRD"), "IPD", "IPDB", IPBuilder.class);
-        dataBuilderMetadataManager.register(ImmutableSet.of("IPD", "EPD", "OO"), "DPD", "DPDB", DPBuilder.class);
-        dataBuilderMetadataManager.register(ImmutableSet.of("DPD", "IPD", "OO"), "OMSP", "OMSPD", OPBuilder.class);
-        dataBuilderMetadataManager.register(ImmutableSet.of("OMSP", "OO", "DPD"), "PSD", "PSDB", PSBuilder.class);
-        dataBuilderMetadataManager.register(ImmutableSet.of("PSD", "OMSP", "OO"), "PPD", "PPDB", PPBuilder.class);
-        dataBuilderMetadataManager.register(ImmutableSet.of("PPD", "PSD"), "OCD", "OCDB", OCBuilder.class);
 
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
@@ -47,74 +52,69 @@ public class FlowTest {
 
     @Test
     public void testRunMultiStep() throws Exception {
-        DataFlow dataFlow = new DataFlow();
+        val dataFlow = new DataFlow()
+                .setName("TestFlow")
+                .setTargetData("OCD");
 
-        dataFlow.setName("TestFlow");
-        dataFlow.setTargetData("OCD");
-
-        ExecutionGraph e = executionGraphGenerator.generateGraph(dataFlow);
+        val e = executionGraphGenerator.generateGraph(dataFlow);
         dataFlow.setExecutionGraph(e);
 
-        DataFlowInstance dataFlowInstance = new DataFlowInstance("Test", dataFlow, new DataSet());
-        ExecutionGraph executionGraph = dataFlowInstance.getDataFlow().getExecutionGraph();
+        val dataFlowInstance = new DataFlowInstance("Test", dataFlow, new DataSet());
+        val executionGraph = dataFlowInstance.getDataFlow().getExecutionGraph();
         assertNotNull(executionGraph);
-        List<List<DataBuilderMeta>> dependencyGraph = executionGraph.getDependencyHierarchy();
+        val dependencyGraph = executionGraph.getDependencyHierarchy();
         assertEquals(10, dependencyGraph.size());
 
         {
-            DataDelta dataDelta = new DataDelta(Lists.newArrayList(
+            val dataDelta = new DataDelta(Lists.newArrayList(
                     new CAID(), new CR(), new OP()));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+            val response = executor.run(dataFlowInstance, dataDelta);
             log.info(listPrint(response.getResponses().keySet()));
-            Assert.assertEquals(3, response.getResponses().size());
+            assertEquals(3, response.getResponses().size());
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(
                     new SPO()));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+            val response = executor.run(dataFlowInstance, dataDelta);
             log.info(listPrint(response.getResponses().keySet()));
-            Assert.assertEquals(2, response.getResponses().size());
+            assertEquals(2, response.getResponses().size());
         }
         {
-            DataDelta dataDelta = new DataDelta(Lists.<Data>newArrayList(
+            val dataDelta = new DataDelta(Lists.<Data>newArrayList(
                     new EPD()));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+            val response = executor.run(dataFlowInstance, dataDelta);
             log.info(listPrint(response.getResponses().keySet()));
-            Assert.assertEquals(5, response.getResponses().size());
+            assertEquals(5, response.getResponses().size());
         }
     }
 
     @Test
     public void testRunSingleStep() throws Exception {
-        DataFlow dataFlow = new DataFlow();
+        val dataFlow = new DataFlow();
 
         dataFlow.setName("TestFlow");
         dataFlow.setTargetData("OCD");
 
-        ExecutionGraph e = executionGraphGenerator.generateGraph(dataFlow);
+        val e = executionGraphGenerator.generateGraph(dataFlow);
         dataFlow.setExecutionGraph(e);
 
-        DataFlowInstance dataFlowInstance = new DataFlowInstance("Test", dataFlow, new DataSet());
-        ExecutionGraph executionGraph = dataFlowInstance.getDataFlow().getExecutionGraph();
+        val dataFlowInstance = new DataFlowInstance("Test", dataFlow, new DataSet());
+        val executionGraph = dataFlowInstance.getDataFlow().getExecutionGraph();
         assertNotNull(executionGraph);
-        List<List<DataBuilderMeta>> dependencyGraph = executionGraph.getDependencyHierarchy();
+        val dependencyGraph = executionGraph.getDependencyHierarchy();
         assertEquals(10, dependencyGraph.size());
 
         {
-            DataDelta dataDelta = new DataDelta(Lists.newArrayList(
+            val dataDelta = new DataDelta(Lists.newArrayList(
                     new CAID(), new CR(), new OP(), new SPO(), new EPD()));
-            DataExecutionResponse response = executor.run(dataFlowInstance, dataDelta);
+            val response = executor.run(dataFlowInstance, dataDelta);
             log.info(listPrint(response.getResponses().keySet()));
-            Assert.assertEquals(10, response.getResponses().size());
+            assertEquals(10, response.getResponses().size());
         }
     }
 
     private String listPrint(Collection<String> dataset) {
-        StringBuilder stringBuilder = new StringBuilder();
-        for(String data : dataset) {
-            stringBuilder.append(data + ", ");
-        }
-        return stringBuilder.toString();
+        return Joiner.on(',').join(dataset);
     }
 
 }

--- a/src/test/java/io/appform/databuilderframework/flowtest/tests/LoopTest.java
+++ b/src/test/java/io/appform/databuilderframework/flowtest/tests/LoopTest.java
@@ -2,17 +2,14 @@ package io.appform.databuilderframework.flowtest.tests;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.appform.databuilderframework.engine.DataBuilderMetadataManager;
-import io.appform.databuilderframework.engine.DataFlowExecutor;
-import io.appform.databuilderframework.engine.ExecutionGraphGenerator;
-import io.appform.databuilderframework.engine.MultiThreadedDataFlowExecutor;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import io.appform.databuilderframework.engine.*;
 import io.appform.databuilderframework.engine.impl.InstantiatingDataBuilderFactory;
 import io.appform.databuilderframework.flowtest.builders.*;
 import io.appform.databuilderframework.flowtest.data.*;
 import io.appform.databuilderframework.model.*;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
 import org.junit.Test;
@@ -28,6 +25,7 @@ import static org.junit.Assert.assertNotNull;
 public class LoopTest {
     private DataBuilderMetadataManager dataBuilderMetadataManager = new DataBuilderMetadataManager();
     private DataFlowExecutor executor = new MultiThreadedDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager), Executors.newFixedThreadPool(10));
+//    private DataFlowExecutor executor = new SimpleDataFlowExecutor(new InstantiatingDataBuilderFactory(dataBuilderMetadataManager));
     private ExecutionGraphGenerator executionGraphGenerator = new ExecutionGraphGenerator(dataBuilderMetadataManager);
     private ObjectMapper mapper = new ObjectMapper();
 

--- a/src/test/java/io/appform/databuilderframework/model/DataBuilderMetaTest.java
+++ b/src/test/java/io/appform/databuilderframework/model/DataBuilderMetaTest.java
@@ -1,62 +1,66 @@
 package io.appform.databuilderframework.model;
 
 import com.google.common.collect.ImmutableSet;
+import lombok.val;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class DataBuilderMetaTest {
     @Test
     public void testEquals() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
-        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
-        Assert.assertEquals(lhs, rhs);
-        Assert.assertEquals(lhs.hashCode(), rhs.hashCode());
+        val lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
+        val rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
+        assertEquals(lhs, rhs);
+        assertEquals(lhs.hashCode(), rhs.hashCode());
     }
     
     @Test
     public void testEqualsWithOptionalsAndAccess() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test",ImmutableSet.of("O"),ImmutableSet.of("G"));
-        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test",ImmutableSet.of("O"),ImmutableSet.of("G"));
-        Assert.assertEquals(lhs, rhs);
-        Assert.assertEquals(lhs.hashCode(), rhs.hashCode());
+        val lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test",ImmutableSet.of("O"),ImmutableSet.of("G"));
+        val rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test",ImmutableSet.of("O"),ImmutableSet.of("G"));
+        assertEquals(lhs, rhs);
+        assertEquals(lhs.hashCode(), rhs.hashCode());
     }
 
 
     
     @Test
     public void testNotEquals1() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
-        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test1");
-        Assert.assertFalse(lhs.equals(rhs));
+        val lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
+        val rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test1");
+        assertNotEquals(lhs, rhs);
     }
     
     @Test
     public void testNotEquals2() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
-        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "D", "test");
-        Assert.assertFalse(lhs.equals(rhs));
+        val lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
+        val rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "D", "test");
+        assertNotEquals(lhs, rhs);
     }
 
     @Test
     public void testNotEquals3() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
-        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "X"), "C", "test");
-        Assert.assertFalse(lhs.equals(rhs));
+        val lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
+        val rhs = new DataBuilderMeta(ImmutableSet.of("A", "X"), "C", "test");
+        assertNotEquals(lhs, rhs);
     }
 
     @Test
     public void testNotEquals4() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
-        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A"), "D", "test");
-        Assert.assertFalse(lhs.equals(rhs));
+        val lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
+        val rhs = new DataBuilderMeta(ImmutableSet.of("A"), "D", "test");
+        assertNotEquals(lhs, rhs);
     }
 
     @Test
     public void testNotEquals5() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
-        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "X"), "D", "test");
-        Assert.assertFalse(lhs.equals(rhs));
-        Assert.assertFalse(lhs.hashCode() == rhs.hashCode());
+        val lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
+        val rhs = new DataBuilderMeta(ImmutableSet.of("A", "X"), "D", "test");
+        assertNotEquals(lhs, rhs);
+        assertNotEquals(lhs.hashCode(), rhs.hashCode());
     }
 
     @Test
@@ -67,34 +71,34 @@ public class DataBuilderMetaTest {
 
     @Test
     public void testNotEquals7() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
-        Assert.assertFalse(lhs.equals(null));
+        val lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
+        assertNotEquals(null, lhs);
     }
 
     @Test
     public void testNotEquals8() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
-        Assert.assertFalse(lhs.equals(new Integer(100)));
+        val lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
+        assertNotEquals(lhs, new Integer(100));
     }
     
     @Test
     public void testNotEqualsWithOptionalsAndAccess1() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test",ImmutableSet.of("O","H"),ImmutableSet.of("G"));
-        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test",ImmutableSet.of("O"),ImmutableSet.of("G"));
-        Assert.assertFalse(lhs.equals(rhs));
+        val lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test",ImmutableSet.of("O","H"),ImmutableSet.of("G"));
+        val rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test",ImmutableSet.of("O"),ImmutableSet.of("G"));
+        assertNotEquals(lhs, rhs);
     }
     
     @Test
     public void testNotEqualsWithOptionalsAndAccess2() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test",ImmutableSet.of("O"),ImmutableSet.of("G"));
-        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test",ImmutableSet.of("O"),ImmutableSet.of("H"));
-        Assert.assertFalse(lhs.equals(rhs));
+        val lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test",ImmutableSet.of("O"),ImmutableSet.of("G"));
+        val rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test",ImmutableSet.of("O"),ImmutableSet.of("H"));
+        assertNotEquals(lhs, rhs);
     }
 
     @Test
     public void testNotEqualsWithOptionalsAndAccess3() {
-        DataBuilderMeta lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test",ImmutableSet.of("O"),ImmutableSet.of("G"));
-        DataBuilderMeta rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
-        Assert.assertFalse(lhs.equals(rhs));
+        val lhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test",ImmutableSet.of("O"),ImmutableSet.of("G"));
+        val rhs = new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test");
+        assertNotEquals(lhs, rhs);
     }
 }

--- a/src/test/java/io/appform/databuilderframework/model/ExecutionGraphTest.java
+++ b/src/test/java/io/appform/databuilderframework/model/ExecutionGraphTest.java
@@ -2,27 +2,30 @@ package io.appform.databuilderframework.model;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import org.junit.Assert;
+import lombok.val;
 import org.junit.Test;
 
 import java.util.Collections;
 import java.util.List;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
 public class ExecutionGraphTest {
     @Test
     public void testDeepCopyEmpty() throws Exception {
-        ExecutionGraph executionGraph = new ExecutionGraph(Collections.<List<DataBuilderMeta>>emptyList());
-        ExecutionGraph executionGraph1 = executionGraph.deepCopy();
-        Assert.assertEquals(0, executionGraph1.getDependencyHierarchy().size());
+        val executionGraph = new ExecutionGraph(Collections.<List<DataBuilderMeta>>emptyList());
+        val executionGraph1 = executionGraph.deepCopy();
+        assertEquals(0, executionGraph1.getDependencyHierarchy().size());
     }
 
     @Test
     public void testDeepCopy() throws Exception {
-        List<DataBuilderMeta> builders = Lists.newArrayList(
+        val builders = Lists.newArrayList(
                                             new DataBuilderMeta(ImmutableSet.of("A", "B"), "C", "test"));
-        ExecutionGraph executionGraph = new ExecutionGraph(Collections.singletonList(builders));
-        ExecutionGraph executionGraph1 = executionGraph.deepCopy();
-        Assert.assertArrayEquals(executionGraph.getDependencyHierarchy().get(0).toArray(new DataBuilderMeta[executionGraph.getDependencyHierarchy().size()]),
+        val executionGraph = new ExecutionGraph(Collections.singletonList(builders));
+        val executionGraph1 = executionGraph.deepCopy();
+        assertArrayEquals(executionGraph.getDependencyHierarchy().get(0).toArray(new DataBuilderMeta[executionGraph.getDependencyHierarchy().size()]),
                 executionGraph1.getDependencyHierarchy().get(0).toArray(new DataBuilderMeta[executionGraph.getDependencyHierarchy().size()]));
     }
 }

--- a/src/test/resources/execgraphgentest.json
+++ b/src/test/resources/execgraphgentest.json
@@ -1,0 +1,150 @@
+{
+  "dependencyHierarchy" : [ [ {
+    "consumes" : [ "A" ],
+    "produces" : "A1",
+    "name" : "BuilderA1",
+    "rank" : 9,
+    "optionals" : [ ],
+    "access" : [ ]
+  } ], [ {
+    "consumes" : [ "A", "A1" ],
+    "produces" : "B1",
+    "name" : "BuilderB1",
+    "rank" : 8,
+    "optionals" : [ ],
+    "access" : [ ]
+  }, {
+    "consumes" : [ "A", "A1" ],
+    "produces" : "B2",
+    "name" : "BuilderB2",
+    "rank" : 8,
+    "optionals" : [ ],
+    "access" : [ ]
+  }, {
+    "consumes" : [ "A", "A1" ],
+    "produces" : "B3",
+    "name" : "BuilderB3",
+    "rank" : 8,
+    "optionals" : [ ],
+    "access" : [ ]
+  }, {
+    "consumes" : [ "A" ],
+    "produces" : "A2",
+    "name" : "BuilderA2",
+    "rank" : 8,
+    "optionals" : [ ],
+    "access" : [ ]
+  }, {
+    "consumes" : [ "A", "A1" ],
+    "produces" : "B4",
+    "name" : "BuilderB4",
+    "rank" : 8,
+    "optionals" : [ ],
+    "access" : [ ]
+  }, {
+    "consumes" : [ "A", "A1" ],
+    "produces" : "B5",
+    "name" : "BuilderB5",
+    "rank" : 8,
+    "optionals" : [ ],
+    "access" : [ ]
+  } ], [ {
+    "consumes" : [ "A" ],
+    "produces" : "C",
+    "name" : "BuilderC",
+    "rank" : 7,
+    "optionals" : [ "A1", "A2", "B1", "B2", "B3", "B4", "B5" ],
+    "access" : [ ]
+  } ], [ {
+    "consumes" : [ "A", "C" ],
+    "produces" : "D",
+    "name" : "BuilderD",
+    "rank" : 6,
+    "optionals" : [ ],
+    "access" : [ ]
+  } ], [ {
+    "consumes" : [ "D" ],
+    "produces" : "E1",
+    "name" : "BuilderE1",
+    "rank" : 5,
+    "optionals" : [ ],
+    "access" : [ "A", "C" ]
+  } ], [ {
+    "consumes" : [ "E1" ],
+    "produces" : "F",
+    "name" : "BuilderF",
+    "rank" : 4,
+    "optionals" : [ ],
+    "access" : [ "A", "C", "D" ]
+  } ], [ {
+    "consumes" : [ "F" ],
+    "produces" : "G",
+    "name" : "BuilderG",
+    "rank" : 3,
+    "optionals" : [ ],
+    "access" : [ "C", "D", "E1" ]
+  }, {
+    "consumes" : [ "D" ],
+    "produces" : "E2",
+    "name" : "BuilderE2",
+    "rank" : 3,
+    "optionals" : [ ],
+    "access" : [ "A", "C" ]
+  }, {
+    "consumes" : [ "D" ],
+    "produces" : "E3",
+    "name" : "BuilderE3",
+    "rank" : 3,
+    "optionals" : [ ],
+    "access" : [ "A", "C" ]
+  }, {
+    "consumes" : [ "D" ],
+    "produces" : "E4",
+    "name" : "BuilderE4",
+    "rank" : 3,
+    "optionals" : [ ],
+    "access" : [ "A", "C" ]
+  }, {
+    "consumes" : [ "D" ],
+    "produces" : "E5",
+    "name" : "BuilderE5",
+    "rank" : 3,
+    "optionals" : [ ],
+    "access" : [ "A", "C" ]
+  }, {
+    "consumes" : [ "D", "IE6" ],
+    "produces" : "E6",
+    "name" : "BuilderE6",
+    "rank" : 3,
+    "optionals" : [ ],
+    "access" : [ "A", "C" ]
+  }, {
+    "consumes" : [ "A", "IA" ],
+    "produces" : "A3",
+    "name" : "BuilderA3",
+    "rank" : 3,
+    "optionals" : [ ],
+    "access" : [ ]
+  } ], [ {
+    "consumes" : [ "C", "A3" ],
+    "produces" : "I",
+    "name" : "BuilderI",
+    "rank" : 2,
+    "optionals" : [ "E2", "E3", "E4", "E5", "E6", "F", "G", "IE6" ],
+    "access" : [ "A" ]
+  } ], [ {
+    "consumes" : [ "I" ],
+    "produces" : "J",
+    "name" : "BuilderJ",
+    "rank" : 1,
+    "optionals" : [ ],
+    "access" : [ "A", "E2", "E3", "E4", "E5", "E6", "F", "G", "IE6", "J" ]
+  } ], [ {
+    "consumes" : [ "J" ],
+    "produces" : "K",
+    "name" : "BuilderK",
+    "rank" : 0,
+    "optionals" : [ ],
+    "access" : [ "A", "C" ]
+  } ] ]
+}


### PR DESCRIPTION
* Replaced generated functions with lombok in multiple places
* Replaced explicit type with val in multiple places
* Fixed issue in DataSet where available data was getting multified in a racey manner. Now protected by a StampedLock for performance
* Fixed testcases where there were no assertions
* Deprecated the getDataSet(builder) function as the access is already on a scoped immutable DataSet
* Undeprecated older getDataSet() function